### PR TITLE
ignorePlurals: accept a list of ISO codes

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/IgnorePlurals.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/IgnorePlurals.java
@@ -1,0 +1,103 @@
+package com.algolia.search.objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@JsonDeserialize(using = IgnorePluralsDeserializer.class)
+@JsonSerialize(using = IgnorePluralsSerializer.class)
+public abstract class IgnorePlurals {
+
+  public static IgnorePlurals of(Boolean bool) {
+    return new IgnorePluralsBoolean(bool);
+  }
+
+  public static IgnorePlurals of(List<String> strings) {
+    return new IgnorePluralsListString(strings);
+  }
+
+  @JsonIgnore
+  abstract Object getInsideValue();
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    IgnorePlurals that = (IgnorePlurals) o;
+
+    return getInsideValue() != null ? getInsideValue().equals(that.getInsideValue()) : that.getInsideValue() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    return getInsideValue() != null ? getInsideValue().hashCode() : 0;
+  }
+}
+
+class IgnorePluralsBoolean extends IgnorePlurals {
+
+  private boolean insideValue;
+
+  IgnorePluralsBoolean(boolean insideValue) {
+    this.insideValue = insideValue;
+  }
+
+  @Override
+  Object getInsideValue() {
+    return insideValue;
+  }
+}
+
+class IgnorePluralsListString extends IgnorePlurals {
+
+  private List<String> insideValue;
+
+  IgnorePluralsListString(List<String> insideValue) {
+    this.insideValue = insideValue;
+  }
+
+  @Override
+  Object getInsideValue() {
+    return insideValue;
+  }
+}
+
+class IgnorePluralsDeserializer extends JsonDeserializer<IgnorePlurals> {
+
+  @Override
+  public IgnorePlurals deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    JsonToken currentToken = p.getCurrentToken();
+    if (currentToken.equals(JsonToken.VALUE_STRING)) {
+      return IgnorePlurals.of(Arrays.asList(p.getValueAsString().split(",")));
+    }
+
+    return IgnorePlurals.of(p.getBooleanValue());
+  }
+}
+
+class IgnorePluralsSerializer extends JsonSerializer<IgnorePlurals> {
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void serialize(IgnorePlurals value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+    if (value instanceof IgnorePluralsBoolean) {
+      gen.writeBoolean((Boolean) value.getInsideValue());
+    } else if (value instanceof IgnorePluralsListString) {
+      List<String> list = (List<String>) value.getInsideValue();
+      gen.writeString(String.join(",", list));
+    }
+  }
+}

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/IndexSettings.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/IndexSettings.java
@@ -44,7 +44,7 @@ public class IndexSettings {
   private String highlightPostTag;
   private List<String> optionalWords;
   private Boolean allowTyposOnNumericTokens;
-  private Boolean ignorePlurals;
+  private IgnorePlurals ignorePlurals;
   private Boolean advancedSyntax;
   private String removeWordsIfNoResults;
   private Boolean replaceSynonymsInHighlight;
@@ -154,7 +154,7 @@ public class IndexSettings {
     return allowTyposOnNumericTokens;
   }
 
-  public Boolean getIgnorePlurals() {
+  public IgnorePlurals getIgnorePlurals() {
     return ignorePlurals;
   }
 
@@ -310,7 +310,18 @@ public class IndexSettings {
     return this;
   }
 
+  @JsonIgnore
   public IndexSettings setIgnorePlurals(Boolean ignorePlurals) {
+    return this.setIgnorePlurals(IgnorePlurals.of(ignorePlurals));
+  }
+
+  @JsonIgnore
+  public IndexSettings setIgnorePlurals(List<String> ignorePlurals) {
+    return this.setIgnorePlurals(IgnorePlurals.of(ignorePlurals));
+  }
+
+  @JsonProperty
+  public IndexSettings setIgnorePlurals(IgnorePlurals ignorePlurals) {
     this.ignorePlurals = ignorePlurals;
     return this;
   }

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/Query.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/Query.java
@@ -19,7 +19,7 @@ public class Query {
   private Integer minWordSizeForApprox1;
   private Integer minWordSizeForApprox2;
   private Boolean allowTyposOnNumericTokens;
-  private Boolean ignorePlural;
+  private IgnorePlurals ignorePlural;
   private String restrictSearchableAttributes;
   private Boolean advancedSyntax;
   private Boolean analytics;
@@ -266,8 +266,13 @@ public class Query {
     return this;
   }
 
-  public Query setIgnorePlural(Boolean ignorePlural) {
-    this.ignorePlural = ignorePlural;
+  public Query setIgnorePlural(Boolean ignorePlurals) {
+    this.ignorePlural = IgnorePlurals.of(ignorePlurals);
+    return this;
+  }
+
+  public Query setIgnorePlural(List<String> isoCodes) {
+    this.ignorePlural = IgnorePlurals.of(isoCodes);
     return this;
   }
 

--- a/algoliasearch-common/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-common/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -2,6 +2,7 @@ package com.algolia.search;
 
 import com.algolia.search.inputs.synonym.*;
 import com.algolia.search.objects.Distinct;
+import com.algolia.search.objects.IgnorePlurals;
 import com.algolia.search.objects.IndexSettings;
 import com.algolia.search.objects.RemoveStopWords;
 import org.junit.Test;
@@ -82,6 +83,34 @@ public class JacksonParserTest {
 
     removeStopWords = DEFAULT_OBJECT_MAPPER.readValue("{\"removeStopWords\":\"a,b\"}", IndexSettings.class).getRemoveStopWords();
     assertThat(removeStopWords).isEqualTo(RemoveStopWords.of(Arrays.asList("a", "b")));
+  }
+
+  @Test
+  public void serializeIgnorePlurals() throws IOException {
+    IndexSettings settings;
+
+    settings = new IndexSettings().setIgnorePlurals(true);
+    assertThat(DEFAULT_OBJECT_MAPPER.writeValueAsString(settings)).isEqualTo("{\"ignorePlurals\":true}");
+
+    settings = new IndexSettings().setIgnorePlurals(IgnorePlurals.of(Arrays.asList("en")));
+    assertThat(DEFAULT_OBJECT_MAPPER.writeValueAsString(settings)).isEqualTo("{\"ignorePlurals\":\"en\"}");
+
+    settings = new IndexSettings().setIgnorePlurals(Arrays.asList("en", "fr"));
+    assertThat(DEFAULT_OBJECT_MAPPER.writeValueAsString(settings)).isEqualTo("{\"ignorePlurals\":\"en,fr\"}");
+  }
+
+  @Test
+  public void deserializeIgnorePlurals() throws IOException {
+    IgnorePlurals ignorePlurals;
+
+    ignorePlurals = DEFAULT_OBJECT_MAPPER.readValue("{\"ignorePlurals\":true}", IndexSettings.class).getIgnorePlurals();
+    assertThat(ignorePlurals).isEqualTo(IgnorePlurals.of(true));
+
+    ignorePlurals = DEFAULT_OBJECT_MAPPER.readValue("{\"ignorePlurals\":\"en\"}", IndexSettings.class).getIgnorePlurals();
+    assertThat(ignorePlurals).isEqualTo(IgnorePlurals.of(Arrays.asList("en")));
+
+    ignorePlurals = DEFAULT_OBJECT_MAPPER.readValue("{\"ignorePlurals\":\"en,fr\"}", IndexSettings.class).getIgnorePlurals();
+    assertThat(ignorePlurals).isEqualTo(IgnorePlurals.of(Arrays.asList("en", "fr")));
   }
 
 }


### PR DESCRIPTION
@ElPicador Is this what you were expecting? I used a class with inner classes to avoid creating multiple `.java` files, but that may be clearer than this.