### PR TITLE
refactor(client): Split Index & AsyncIndex in multiple classes

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -291,7 +291,7 @@ public class APIClient {
           TaskStatus.class)
       );
 
-      if (Objects.equals("published", status.getStatus())) {
+      if (java.util.Objects.equals("published", status.getStatus())) {
         return;
       }
       try {
@@ -653,7 +653,7 @@ public class APIClient {
 
   TaskSingleIndex batch(String indexName, List<BatchOperation> operations) throws AlgoliaException {
     //Special case for single index batches, indexName of operations should be null
-    boolean onSameIndex = operations.stream().allMatch(o -> Objects.equals(null, o.getIndexName()));
+    boolean onSameIndex = operations.stream().allMatch(o -> java.util.Objects.equals(null, o.getIndexName()));
     if (!onSameIndex) {
       throw new AlgoliaException("All operations are not on the same index");
     }

--- a/algoliasearch-common/src/main/java/com/algolia/search/AbstractIndex.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AbstractIndex.java
@@ -1,13 +1,13 @@
 package com.algolia.search;
 
-abstract public class AbstractIndex<T> {
+public interface AbstractIndex<T> {
 
-  abstract public String getName();
+  String getName();
 
-  abstract public Class<T> getKlass();
+  Class<T> getKlass();
 
   @SuppressWarnings("unused")
-  public static class Attributes {
+  class Attributes {
     private String name;
     private String createdAt;
     private String updatedAt;

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -305,7 +305,7 @@ public class AsyncAPIClient {
         break;
       }
 
-      if (Objects.equals("published", result.getStatus())) {
+      if (java.util.Objects.equals("published", result.getStatus())) {
         return;
       }
       try {
@@ -647,7 +647,7 @@ public class AsyncAPIClient {
 
   CompletableFuture<AsyncTaskSingleIndex> batch(String indexName, List<BatchOperation> operations) {
     //Special case for single index batches, indexName of operations should be null
-    boolean onSameIndex = operations.stream().allMatch(o -> Objects.equals(null, o.getIndexName()));
+    boolean onSameIndex = operations.stream().allMatch(o -> java.util.Objects.equals(null, o.getIndexName()));
     if (!onSameIndex) {
       Utils.completeExceptionally(new AlgoliaException("All operations are not on the same index"));
     }

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndex.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndex.java
@@ -18,8 +18,554 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+interface BaseAsyncIndex<T> extends AbstractIndex<T> {
+
+  AsyncAPIClient getApiClient();
+
+}
+
+interface AsyncIndexCRUD<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Moves an existing index
+   *
+   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overriten if it already exist)
+   * @return The task associated
+   */
+  default CompletableFuture<AsyncTask> moveTo(@Nonnull String dstIndexName) {
+    return getApiClient().moveIndex(getName(), dstIndexName);
+  }
+
+  /**
+   * Copy an existing index
+   *
+   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overridden if it already exist)
+   * @return The task associated
+   */
+  default CompletableFuture<AsyncTask> copyTo(@Nonnull String dstIndexName) {
+    return getApiClient().copyIndex(getName(), dstIndexName);
+  }
+
+  /**
+   * Deletes the index
+   *
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTask> delete() {
+    return getApiClient().deleteIndex(getName());
+  }
+
+  /**
+   * Delete the index content without removing settings and index specific API keys.
+   *
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTask> clear() {
+    return getApiClient().clearIndex(getName());
+  }
+
+}
+
+interface AsyncTasks<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Wait for the completion of a task
+   *
+   * @param task       task to wait for
+   * @param timeToWait the time to wait in milliseconds
+   */
+  default void waitTask(@Nonnull AsyncTask task, long timeToWait) {
+    Preconditions.checkArgument(timeToWait >= 0, "timeToWait must be >= 0, was %s", timeToWait);
+    getApiClient().waitTask(task, timeToWait);
+  }
+
+  /**
+   * Wait for the completion of a task, for 100ms
+   *
+   * @param task task to wait for
+   */
+  default void waitTask(@Nonnull AsyncTask task) {
+    getApiClient().waitTask(task, 100);
+  }
+
+
+}
+
+interface AsyncObjects<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Add an object in this index
+   *
+   * @param object object to add
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTaskIndexing> addObject(@Nonnull T object) {
+    return getApiClient().addObject(getName(), object);
+  }
+
+  /**
+   * Add an object in this index with a unique identifier
+   *
+   * @param objectID the objectID associated to this object
+   *                 (if this objectID already exist the old object will be overridden)
+   * @param object   object to add
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTaskIndexing> addObject(@Nonnull String objectID, @Nonnull T object) {
+    return getApiClient().addObject(getName(), objectID, object);
+  }
+
+  /**
+   * Add several objects
+   *
+   * @param objects objects to add
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> addObjects(@Nonnull List<T> objects) {
+    return getApiClient().addObjects(getName(), objects);
+  }
+
+  /**
+   * Get an object from this index
+   *
+   * @param objectID the unique identifier of the object to retrieve
+   * @return The object
+   */
+  default CompletableFuture<Optional<T>> getObject(@Nonnull String objectID) {
+    return getApiClient().getObject(getName(), objectID, getKlass());
+  }
+
+  /**
+   * Get several objects from this index
+   *
+   * @param objectIDs the list of unique identifier of objects to retrieve
+   * @return the list of objects
+   */
+  default CompletableFuture<List<T>> getObjects(@Nonnull List<String> objectIDs) {
+    return getApiClient().getObjects(getName(), objectIDs, getKlass());
+  }
+
+  /**
+   * Get several objects from this index
+   *
+   * @param objectIDs            the list of unique identifier of objects to retrieve
+   * @param attributesToRetrieve the list of attributes to retrieve for these objects
+   * @return the list of objects
+   */
+  default CompletableFuture<List<T>> getObjects(@Nonnull List<String> objectIDs, @Nonnull List<String> attributesToRetrieve) {
+    return getApiClient().getObjects(getName(), objectIDs, attributesToRetrieve, getKlass());
+  }
+
+  /**
+   * Override the content of object
+   *
+   * @param objectID the unique identifier of the object to retrieve
+   * @param object   the object to update
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTask> saveObject(@Nonnull String objectID, @Nonnull T object) {
+    return getApiClient().saveObject(getName(), objectID, object);
+  }
+
+  /**
+   * Override the content the list of objects
+   *
+   * @param objects the list objects to update
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> saveObjects(@Nonnull List<T> objects) {
+    return getApiClient().saveObjects(getName(), objects);
+  }
+
+  /**
+   * Delete an object from the index
+   *
+   * @param objectID the unique identifier of the object to retrieve
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTask> deleteObject(@Nonnull String objectID) {
+    return getApiClient().deleteObject(getName(), objectID);
+  }
+
+  /**
+   * Delete objects from the index
+   *
+   * @param objectIDs the list of unique identifier of the object to retrieve
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> deleteObjects(@Nonnull List<String> objectIDs) {
+    return getApiClient().deleteObjects(getName(), objectIDs);
+  }
+
+}
+
+interface AsyncSettings<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Get settings of this index
+   *
+   * @return the settings
+   */
+  default CompletableFuture<IndexSettings> getSettings() {
+    return getApiClient().getSettings(getName());
+  }
+
+  /**
+   * Set settings of this index, and do not forward to slaves
+   *
+   * @param settings the settings to set
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTask> setSettings(@Nonnull IndexSettings settings) {
+    return setSettings(settings, false);
+  }
+
+  /**
+   * Set settings of this index
+   *
+   * @param settings          the settings to set
+   * @param forwardToReplicas should these updates be forwarded to the slaves
+   * @return the related AsyncTask
+   */
+  default CompletableFuture<AsyncTask> setSettings(@Nonnull IndexSettings settings, @Nonnull Boolean forwardToReplicas) {
+    return getApiClient().setSettings(getName(), settings, forwardToReplicas);
+  }
+
+
+}
+
+interface AsyncKey<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Deprecated: use listApiKeys
+   */
+  @Deprecated
+  default CompletableFuture<List<ApiKey>> listKeys() {
+    return listApiKeys();
+  }
+
+  /**
+   * List keys of this index
+   *
+   * @return the list of keys
+   */
+  default CompletableFuture<List<ApiKey>> listApiKeys() {
+    return getApiClient().listKeys(getName());
+  }
+
+  /**
+   * Deprecated: use getApiKey
+   */
+  @Deprecated
+  default CompletableFuture<Optional<ApiKey>> getKey(@Nonnull String key) {
+    return getApiKey(key);
+  }
+
+  /**
+   * Get a key by name from this index
+   *
+   * @param key the key name
+   * @return the key
+   */
+  default CompletableFuture<Optional<ApiKey>> getApiKey(@Nonnull String key) {
+    return getApiClient().getKey(getName(), key);
+  }
+
+  /**
+   * Deprecated: use deleteApiKey
+   */
+  @Deprecated
+  default CompletableFuture<DeleteKey> deleteKey(@Nonnull String key) {
+    return deleteApiKey(key);
+  }
+
+  /**
+   * Delete a key by name from this index
+   *
+   * @param key the key name
+   * @return the deleted key
+   */
+  default CompletableFuture<DeleteKey> deleteApiKey(@Nonnull String key) {
+    return getApiClient().deleteKey(getName(), key);
+  }
+
+  /**
+   * Deprecated: use addApiKey
+   */
+  @Deprecated
+  default CompletableFuture<CreateUpdateKey> addKey(@Nonnull ApiKey key) {
+    return addApiKey(key);
+  }
+
+  /**
+   * Add a key to this index
+   *
+   * @param key the key
+   * @return the created key
+   */
+  default CompletableFuture<CreateUpdateKey> addApiKey(@Nonnull ApiKey key) {
+    return getApiClient().addKey(getName(), key);
+  }
+
+  /**
+   * Deprecated: use updateApiKey
+   */
+  @Deprecated
+  default CompletableFuture<CreateUpdateKey> updateKey(@Nonnull String keyName, @Nonnull ApiKey key) {
+    return updateApiKey(keyName, key);
+  }
+
+  /**
+   * Update a key by name from this index
+   *
+   * @param keyName the key name
+   * @param key     the key to update
+   * @return the updated key
+   */
+  default CompletableFuture<CreateUpdateKey> updateApiKey(@Nonnull String keyName, @Nonnull ApiKey key) {
+    return getApiClient().updateKey(getName(), keyName, key);
+  }
+
+}
+
+interface AsyncSearchForFacet<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Search in a facet
+   *
+   * @param facetName  The name of the facet to search in
+   * @param facetQuery The search query for this facet
+   * @param query      the query (not required)
+   * @return the result of the search
+   */
+  default CompletableFuture<SearchFacetResult> searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) {
+    return getApiClient().searchForFacetValues(getName(), facetName, facetQuery, query);
+  }
+
+  /**
+   * Search in a facet
+   *
+   * @param facetName  The name of the facet to search in
+   * @param facetQuery The search query for this facet
+   * @return the result of the search
+   */
+  default CompletableFuture<SearchFacetResult> searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) {
+    return this.searchForFacetValues(facetName, facetQuery, null);
+  }
+
+  @Deprecated
+  default CompletableFuture<SearchFacetResult> searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) {
+    return this.searchForFacetValues(facetName, facetQuery, query);
+  }
+
+  @Deprecated
+  default CompletableFuture<SearchFacetResult> searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) {
+    return this.searchForFacetValues(facetName, facetQuery, null);
+  }
+
+  @Deprecated
+  default CompletableFuture<SearchFacetResult> searchFacet(@Nonnull String facetName, @Nonnull String facetQuery, Query query) {
+    return this.searchForFacetValues(facetName, facetQuery, query);
+  }
+
+  @Deprecated
+  default CompletableFuture<SearchFacetResult> searchFacet(@Nonnull String facetName, @Nonnull String facetQuery) {
+    return this.searchForFacetValues(facetName, facetQuery);
+  }
+
+}
+
+interface AsyncPartialUpdate<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Partially update an object
+   *
+   * @param objectID the ID of object to update
+   * @param object   the object to update
+   * @return the associated task
+   * @see PartialUpdateOperation & subclasses
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObject(@Nonnull String objectID, @Nonnull Object object) {
+    return getApiClient().partialUpdateObject(getName(), objectID, object);
+  }
+
+  /**
+   * Partially update a objects
+   *
+   * @param objects the list of objects to update (with an objectID)
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObjects(@Nonnull List<Object> objects) {
+    return getApiClient().partialUpdateObjects(getName(), objects);
+  }
+
+  /**
+   * Partially update an object, create the object if it does not exist
+   *
+   * @param operation the operation to perform on this object
+   * @return the associated task
+   * @see PartialUpdateOperation & subclasses
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObject(@Nonnull PartialUpdateOperation operation) {
+    return partialUpdateObject(operation, true);
+  }
+
+  /**
+   * Partially update an object
+   *
+   * @param operation         the operation to perform on this object
+   * @param createIfNotExists should the object be created or not
+   * @return the associated task
+   * @see PartialUpdateOperation & subclasses
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObject(@Nonnull PartialUpdateOperation operation, boolean createIfNotExists) {
+    return getApiClient().partialUpdateObject(getName(), operation, createIfNotExists);
+  }
+
+}
+
+interface AsyncSynonyms<T> extends BaseAsyncIndex<T> {
+
+  /**
+   * Saves/updates a synonym without replacing it and NOT forwarding it to the slaves
+   *
+   * @param synonymID the id of the synonym
+   * @param content   the synonym
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content) {
+    return saveSynonym(synonymID, content, false);
+  }
+
+  /**
+   * Saves/updates a synonym without replacing
+   *
+   * @param synonymID         the id of the synonym
+   * @param content           the synonym
+   * @param forwardToReplicas should this request be forwarded to slaves
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas) {
+    return saveSynonym(synonymID, content, forwardToReplicas, false);
+  }
+
+  /**
+   * Saves/updates a synonym
+   *
+   * @param synonymID               the id of the synonym
+   * @param content                 the synonym
+   * @param forwardToReplicas       should this request be forwarded to slaves
+   * @param replaceExistingSynonyms should replace if this synonyms exists
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas, boolean replaceExistingSynonyms) {
+    return getApiClient().saveSynonym(getName(), synonymID, content, forwardToReplicas, replaceExistingSynonyms);
+  }
+
+  /**
+   * Get a synonym by ID
+   *
+   * @param synonymID the id of the synonym
+   * @return the associated task
+   */
+  default CompletableFuture<Optional<AbstractSynonym>> getSynonym(@Nonnull String synonymID) {
+    return getApiClient().getSynonym(getName(), synonymID);
+  }
+
+  /**
+   * Deletes a synonym by ID and NOT forwarding it to the slaves
+   *
+   * @param synonymID the id of the synonym
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> deleteSynonym(@Nonnull String synonymID) {
+    return deleteSynonym(synonymID, false);
+  }
+
+  /**
+   * Deletes a synonym
+   *
+   * @param synonymID         the id of the synonym
+   * @param forwardToReplicas should this request be forwarded to slaves
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> deleteSynonym(@Nonnull String synonymID, boolean forwardToReplicas) {
+    return getApiClient().deleteSynonym(getName(), synonymID, forwardToReplicas);
+  }
+
+  /**
+   * Clear all synonyms and NOT forwarding it to the slaves
+   *
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> clearSynonyms() {
+    return clearSynonyms(false);
+  }
+
+  /**
+   * Clears all synonyms
+   *
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> clearSynonyms(boolean forwardToReplicas) {
+    return getApiClient().clearSynonyms(getName(), forwardToReplicas);
+  }
+
+  /**
+   * Search for synonyms
+   *
+   * @param query the query
+   * @return the results of the query
+   */
+  default CompletableFuture<SearchSynonymResult> searchSynonyms(@Nonnull SynonymQuery query) {
+    return getApiClient().searchSynonyms(getName(), query);
+  }
+
+  /**
+   * Add or Replace a list of synonyms
+   *
+   * @param synonyms                List of synonyms
+   * @param forwardToReplicas       Forward the operation to the slave indices
+   * @param replaceExistingSynonyms Replace the existing synonyms with this batch
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas, boolean replaceExistingSynonyms) {
+    return getApiClient().batchSynonyms(getName(), synonyms, forwardToReplicas, replaceExistingSynonyms);
+  }
+
+  /**
+   * Add or Replace a list of synonyms, no replacement
+   *
+   * @param synonyms          List of synonyms
+   * @param forwardToReplicas Forward the operation to the slave indices
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas) {
+    return batchSynonyms(synonyms, forwardToReplicas, false);
+  }
+
+  /**
+   * Add or Replace a list of synonyms, no forward to slaves, and no replacement
+   *
+   * @param synonyms List of synonyms
+   * @return the associated task
+   */
+  default CompletableFuture<AsyncTask> batchSynonyms(@Nonnull List<AbstractSynonym> synonyms) {
+    return batchSynonyms(synonyms, false, false);
+  }
+
+}
+
 @SuppressWarnings("WeakerAccess")
-public class AsyncIndex<T> extends AbstractIndex {
+public class AsyncIndex<T> implements
+  AsyncIndexCRUD<T>,
+  AsyncTasks<T>,
+  AsyncObjects<T>,
+  AsyncSettings<T>,
+  AsyncKey<T>,
+  AsyncSearchForFacet<T>,
+  AsyncPartialUpdate<T>,
+  AsyncSynonyms<T> {
 
   /**
    * Index name
@@ -47,287 +593,8 @@ public class AsyncIndex<T> extends AbstractIndex {
     return klass;
   }
 
-  /**
-   * Add an object in this index
-   *
-   * @param object object to add
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTaskIndexing> addObject(@Nonnull T object) {
-    return client.addObject(name, object);
-  }
-
-  /**
-   * Add an object in this index with a unique identifier
-   *
-   * @param objectID the objectID associated to this object
-   *                 (if this objectID already exist the old object will be overridden)
-   * @param object   object to add
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTaskIndexing> addObject(@Nonnull String objectID, @Nonnull T object) {
-    return client.addObject(name, objectID, object);
-  }
-
-  /**
-   * Add several objects
-   *
-   * @param objects objects to add
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTaskSingleIndex> addObjects(@Nonnull List<T> objects) {
-    return client.addObjects(name, objects);
-  }
-
-  /**
-   * Get an object from this index
-   *
-   * @param objectID the unique identifier of the object to retrieve
-   * @return The object
-   */
-  public CompletableFuture<Optional<T>> getObject(@Nonnull String objectID) {
-    return client.getObject(name, objectID, klass);
-  }
-
-  /**
-   * Get several objects from this index
-   *
-   * @param objectIDs the list of unique identifier of objects to retrieve
-   * @return the list of objects
-   */
-  public CompletableFuture<List<T>> getObjects(@Nonnull List<String> objectIDs) {
-    return client.getObjects(name, objectIDs, klass);
-  }
-
-  /**
-   * Get several objects from this index
-   *
-   * @param objectIDs            the list of unique identifier of objects to retrieve
-   * @param attributesToRetrieve the list of attributes to retrieve for these objects
-   * @return the list of objects
-   */
-  public CompletableFuture<List<T>> getObjects(@Nonnull List<String> objectIDs, @Nonnull List<String> attributesToRetrieve) {
-    return client.getObjects(name, objectIDs, attributesToRetrieve, klass);
-  }
-
-  /**
-   * Wait for the completion of a task
-   *
-   * @param task       task to wait for
-   * @param timeToWait the time to wait in milliseconds
-   */
-  public void waitTask(@Nonnull AsyncTask task, long timeToWait) {
-    Preconditions.checkArgument(timeToWait >= 0, "timeToWait must be >= 0, was %s", timeToWait);
-
-    client.waitTask(task, timeToWait);
-  }
-
-  /**
-   * Wait for the completion of a task, for 100ms
-   *
-   * @param task task to wait for
-   */
-  public void waitTask(@Nonnull AsyncTask task) {
-    client.waitTask(task, 100);
-  }
-
-  /**
-   * Deletes the index
-   *
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTask> delete() {
-    return client.deleteIndex(name);
-  }
-
-  /**
-   * Delete the index content without removing settings and index specific API keys.
-   *
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTask> clear() {
-    return client.clearIndex(name);
-  }
-
-  /**
-   * Override the content of object
-   *
-   * @param objectID the unique identifier of the object to retrieve
-   * @param object   the object to update
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTask> saveObject(@Nonnull String objectID, @Nonnull T object) {
-    return client.saveObject(name, objectID, object);
-  }
-
-  /**
-   * Override the content the list of objects
-   *
-   * @param objects the list objects to update
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTaskSingleIndex> saveObjects(@Nonnull List<T> objects) {
-    return client.saveObjects(name, objects);
-  }
-
-  /**
-   * Delete an object from the index
-   *
-   * @param objectID the unique identifier of the object to retrieve
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTask> deleteObject(@Nonnull String objectID) {
-    return client.deleteObject(name, objectID);
-  }
-
-  /**
-   * Delete objects from the index
-   *
-   * @param objectIDs the list of unique identifier of the object to retrieve
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTaskSingleIndex> deleteObjects(@Nonnull List<String> objectIDs) {
-    return client.deleteObjects(name, objectIDs);
-  }
-
-  /**
-   * Get settings of this index
-   *
-   * @return the settings
-   */
-  public CompletableFuture<IndexSettings> getSettings() {
-    return client.getSettings(name);
-  }
-
-  /**
-   * Set settings of this index, and do not forward to slaves
-   *
-   * @param settings the settings to set
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTask> setSettings(@Nonnull IndexSettings settings) {
-    return setSettings(settings, false);
-  }
-
-  /**
-   * Set settings of this index
-   *
-   * @param settings          the settings to set
-   * @param forwardToReplicas should these updates be forwarded to the slaves
-   * @return the related AsyncTask
-   */
-  public CompletableFuture<AsyncTask> setSettings(@Nonnull IndexSettings settings, @Nonnull Boolean forwardToReplicas) {
-    return client.setSettings(name, settings, forwardToReplicas);
-  }
-
-  /**
-   * Deprecated: use listApiKeys
-   */
-  @Deprecated
-  public CompletableFuture<List<ApiKey>> listKeys() {
-    return listApiKeys();
-  }
-
-  /**
-   * List keys of this index
-   *
-   * @return the list of keys
-   */
-  public CompletableFuture<List<ApiKey>> listApiKeys() {
-    return client.listKeys(name);
-  }
-
-  /**
-   * Deprecated: use getApiKey
-   */
-  @Deprecated
-  public CompletableFuture<Optional<ApiKey>> getKey(@Nonnull String key) {
-    return getApiKey(key);
-  }
-
-  /**
-   * Get a key by name from this index
-   *
-   * @param key the key name
-   * @return the key
-   */
-  public CompletableFuture<Optional<ApiKey>> getApiKey(@Nonnull String key) {
-    return client.getKey(name, key);
-  }
-
-  /**
-   * Deprecated: use deleteApiKey
-   */
-  @Deprecated
-  public CompletableFuture<DeleteKey> deleteKey(@Nonnull String key) {
-    return deleteApiKey(key);
-  }
-
-  /**
-   * Delete a key by name from this index
-   *
-   * @param key the key name
-   * @return the deleted key
-   */
-  public CompletableFuture<DeleteKey> deleteApiKey(@Nonnull String key) {
-    return client.deleteKey(name, key);
-  }
-
-  /**
-   * Deprecated: use addApiKey
-   */
-  @Deprecated
-  public CompletableFuture<CreateUpdateKey> addKey(@Nonnull ApiKey key) {
-    return addApiKey(key);
-  }
-
-  /**
-   * Add a key to this index
-   *
-   * @param key the key
-   * @return the created key
-   */
-  public CompletableFuture<CreateUpdateKey> addApiKey(@Nonnull ApiKey key) {
-    return client.addKey(name, key);
-  }
-
-  /**
-   * Deprecated: use updateApiKey
-   */
-  @Deprecated
-  public CompletableFuture<CreateUpdateKey> updateKey(@Nonnull String keyName, @Nonnull ApiKey key) {
-    return updateApiKey(keyName, key);
-  }
-
-  /**
-   * Update a key by name from this index
-   *
-   * @param keyName the key name
-   * @param key     the key to update
-   * @return the updated key
-   */
-  public CompletableFuture<CreateUpdateKey> updateApiKey(@Nonnull String keyName, @Nonnull ApiKey key) {
-    return client.updateKey(name, keyName, key);
-  }
-
-  /**
-   * Moves an existing index
-   *
-   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overriten if it already exist)
-   * @return The task associated
-   */
-  public CompletableFuture<AsyncTask> moveTo(@Nonnull String dstIndexName) {
-    return client.moveIndex(name, dstIndexName);
-  }
-
-  /**
-   * Copy an existing index
-   *
-   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overridden if it already exist)
-   * @return The task associated
-   */
-  public CompletableFuture<AsyncTask> copyTo(@Nonnull String dstIndexName) {
-    return client.copyIndex(name, dstIndexName);
+  public AsyncAPIClient getApiClient() {
+    return client;
   }
 
   /**
@@ -341,49 +608,6 @@ public class AsyncIndex<T> extends AbstractIndex {
   }
 
   /**
-   * Search in a facet
-   *
-   * @param facetName  The name of the facet to search in
-   * @param facetQuery The search query for this facet
-   * @param query      the query (not required)
-   * @return the result of the search
-   */
-  public CompletableFuture<SearchFacetResult> searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) {
-    return client.searchForFacetValues(name, facetName, facetQuery, query);
-  }
-
-  /**
-   * Search in a facet
-   *
-   * @param facetName  The name of the facet to search in
-   * @param facetQuery The search query for this facet
-   * @return the result of the search
-   */
-  public CompletableFuture<SearchFacetResult> searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) {
-    return this.searchForFacetValues(facetName, facetQuery, null);
-  }
-
-  @Deprecated
-  public CompletableFuture<SearchFacetResult> searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) {
-    return this.searchForFacetValues(facetName, facetQuery, query);
-  }
-
-  @Deprecated
-  public CompletableFuture<SearchFacetResult> searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) {
-    return this.searchForFacetValues(facetName, facetQuery, null);
-  }
-
-  @Deprecated
-  public CompletableFuture<SearchFacetResult> searchFacet(@Nonnull String facetName, @Nonnull String facetQuery, Query query) {
-    return this.searchForFacetValues(facetName, facetQuery, query);
-  }
-
-  @Deprecated
-  public CompletableFuture<SearchFacetResult> searchFacet(@Nonnull String facetName, @Nonnull String facetQuery) {
-    return this.searchForFacetValues(facetName, facetQuery);
-  }
-
-  /**
    * Custom batch
    * <p>
    * All operations must have index name set to <code>null</code>
@@ -394,179 +618,6 @@ public class AsyncIndex<T> extends AbstractIndex {
    */
   public CompletableFuture<AsyncTaskSingleIndex> batch(@Nonnull List<BatchOperation> operations) {
     return client.batch(name, operations);
-  }
-
-  /**
-   * Partially update an object
-   *
-   * @param objectID the ID of object to update
-   * @param object   the object to update
-   * @return the associated task
-   * @see PartialUpdateOperation & subclasses
-   */
-  public CompletableFuture<AsyncTaskSingleIndex> partialUpdateObject(@Nonnull String objectID, @Nonnull Object object) {
-    return client.partialUpdateObject(name, objectID, object);
-  }
-
-  /**
-   * Partially update a objects
-   *
-   * @param objects the list of objects to update (with an objectID)
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTaskSingleIndex> partialUpdateObjects(@Nonnull List<Object> objects) {
-    return client.partialUpdateObjects(name, objects);
-  }
-
-  /**
-   * Partially update an object, create the object if it does not exist
-   *
-   * @param operation the operation to perform on this object
-   * @return the associated task
-   * @see PartialUpdateOperation & subclasses
-   */
-  public CompletableFuture<AsyncTaskSingleIndex> partialUpdateObject(@Nonnull PartialUpdateOperation operation) {
-    return partialUpdateObject(operation, true);
-  }
-
-  /**
-   * Partially update an object
-   *
-   * @param operation         the operation to perform on this object
-   * @param createIfNotExists should the object be created or not
-   * @return the associated task
-   * @see PartialUpdateOperation & subclasses
-   */
-  public CompletableFuture<AsyncTaskSingleIndex> partialUpdateObject(@Nonnull PartialUpdateOperation operation, boolean createIfNotExists) {
-    return client.partialUpdateObject(name, operation, createIfNotExists);
-  }
-
-  /**
-   * Saves/updates a synonym without replacing it and NOT forwarding it to the slaves
-   *
-   * @param synonymID the id of the synonym
-   * @param content   the synonym
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content) {
-    return saveSynonym(synonymID, content, false);
-  }
-
-  /**
-   * Saves/updates a synonym without replacing
-   *
-   * @param synonymID         the id of the synonym
-   * @param content           the synonym
-   * @param forwardToReplicas should this request be forwarded to slaves
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas) {
-    return saveSynonym(synonymID, content, forwardToReplicas, false);
-  }
-
-  /**
-   * Saves/updates a synonym
-   *
-   * @param synonymID               the id of the synonym
-   * @param content                 the synonym
-   * @param forwardToReplicas       should this request be forwarded to slaves
-   * @param replaceExistingSynonyms should replace if this synonyms exists
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas, boolean replaceExistingSynonyms) {
-    return client.saveSynonym(name, synonymID, content, forwardToReplicas, replaceExistingSynonyms);
-  }
-
-  /**
-   * Get a synonym by ID
-   *
-   * @param synonymID the id of the synonym
-   * @return the associated task
-   */
-  public CompletableFuture<Optional<AbstractSynonym>> getSynonym(@Nonnull String synonymID) {
-    return client.getSynonym(name, synonymID);
-  }
-
-  /**
-   * Deletes a synonym by ID and NOT forwarding it to the slaves
-   *
-   * @param synonymID the id of the synonym
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> deleteSynonym(@Nonnull String synonymID) {
-    return deleteSynonym(synonymID, false);
-  }
-
-  /**
-   * Deletes a synonym
-   *
-   * @param synonymID         the id of the synonym
-   * @param forwardToReplicas should this request be forwarded to slaves
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> deleteSynonym(@Nonnull String synonymID, boolean forwardToReplicas) {
-    return client.deleteSynonym(name, synonymID, forwardToReplicas);
-  }
-
-  /**
-   * Clear all synonyms and NOT forwarding it to the slaves
-   *
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> clearSynonyms() {
-    return clearSynonyms(false);
-  }
-
-  /**
-   * Clears all synonyms
-   *
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> clearSynonyms(boolean forwardToReplicas) {
-    return client.clearSynonyms(name, forwardToReplicas);
-  }
-
-  /**
-   * Search for synonyms
-   *
-   * @param query the query
-   * @return the results of the query
-   */
-  public CompletableFuture<SearchSynonymResult> searchSynonyms(@Nonnull SynonymQuery query) {
-    return client.searchSynonyms(name, query);
-  }
-
-  /**
-   * Add or Replace a list of synonyms
-   *
-   * @param synonyms                List of synonyms
-   * @param forwardToReplicas       Forward the operation to the slave indices
-   * @param replaceExistingSynonyms Replace the existing synonyms with this batch
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas, boolean replaceExistingSynonyms) {
-    return client.batchSynonyms(name, synonyms, forwardToReplicas, replaceExistingSynonyms);
-  }
-
-  /**
-   * Add or Replace a list of synonyms, no replacement
-   *
-   * @param synonyms          List of synonyms
-   * @param forwardToReplicas Forward the operation to the slave indices
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas) {
-    return batchSynonyms(synonyms, forwardToReplicas, false);
-  }
-
-  /**
-   * Add or Replace a list of synonyms, no forward to slaves, and no replacement
-   *
-   * @param synonyms List of synonyms
-   * @return the associated task
-   */
-  public CompletableFuture<AsyncTask> batchSynonyms(@Nonnull List<AbstractSynonym> synonyms) {
-    return batchSynonyms(synonyms, false, false);
   }
 
 }

--- a/algoliasearch-common/src/main/java/com/algolia/search/Index.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/Index.java
@@ -19,8 +19,643 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
+interface BaseSyncIndex<T> extends AbstractIndex<T> {
+
+  APIClient getApiClient();
+
+}
+
+interface IndexCRUD<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Deletes the index
+   *
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default Task delete() throws AlgoliaException {
+    return getApiClient().deleteIndex(getName());
+  }
+
+  /**
+   * Delete the index content without removing settings and index specific API keys.
+   *
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default Task clear() throws AlgoliaException {
+    return getApiClient().clearIndex(getName());
+  }
+
+  /**
+   * Moves an existing index
+   *
+   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overriten if it already exist)
+   * @return The task associated
+   * @throws AlgoliaException
+   */
+  default Task moveTo(@Nonnull String dstIndexName) throws AlgoliaException {
+    return getApiClient().moveIndex(getName(), dstIndexName);
+  }
+
+  /**
+   * Copy an existing index
+   *
+   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overridden if it already exist)
+   * @return The task associated
+   * @throws AlgoliaException
+   */
+  default Task copyTo(@Nonnull String dstIndexName) throws AlgoliaException {
+    return getApiClient().copyIndex(getName(), dstIndexName);
+  }
+
+}
+
+interface Tasks<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Wait for the completion of a task
+   *
+   * @param task       task to wait for
+   * @param timeToWait the time to wait in milliseconds
+   * @throws AlgoliaException
+   */
+  default void waitTask(@Nonnull Task task, long timeToWait) throws AlgoliaException {
+    Preconditions.checkArgument(timeToWait >= 0, "timeToWait must be >= 0, was %s", timeToWait);
+
+    getApiClient().waitTask(task, timeToWait);
+  }
+
+  /**
+   * Wait for the completion of a task, for 100ms
+   *
+   * @param task task to wait for
+   * @throws AlgoliaException
+   */
+  default void waitTask(@Nonnull Task task) throws AlgoliaException {
+    getApiClient().waitTask(task, 100);
+  }
+
+}
+
+interface Objects<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Add an object in this index
+   *
+   * @param object object to add
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default TaskIndexing addObject(@Nonnull T object) throws AlgoliaException {
+    return getApiClient().addObject(getName(), object);
+  }
+
+  /**
+   * Add an object in this index with a unique identifier
+   *
+   * @param objectID the objectID associated to this object
+   *                 (if this objectID already exist the old object will be overridden)
+   * @param object   object to add
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default TaskIndexing addObject(@Nonnull String objectID, @Nonnull T object) throws AlgoliaException {
+    return getApiClient().addObject(getName(), objectID, object);
+  }
+
+  /**
+   * Add several objects
+   *
+   * @param objects objects to add
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default TaskSingleIndex addObjects(@Nonnull List<T> objects) throws AlgoliaException {
+    return getApiClient().addObjects(getName(), objects);
+  }
+
+  /**
+   * Get an object from this index
+   *
+   * @param objectID the unique identifier of the object to retrieve
+   * @return The object
+   * @throws AlgoliaException
+   */
+  default Optional<T> getObject(@Nonnull String objectID) throws AlgoliaException {
+    return getApiClient().getObject(getName(), objectID, getKlass());
+  }
+
+  /**
+   * Get several objects from this index
+   *
+   * @param objectIDs the list of unique identifier of objects to retrieve
+   * @return the list of objects
+   * @throws AlgoliaException
+   */
+  default List<T> getObjects(@Nonnull List<String> objectIDs) throws AlgoliaException {
+    return getApiClient().getObjects(getName(), objectIDs, getKlass());
+  }
+
+  /**
+   * Get several objects from this index
+   *
+   * @param objectIDs            the list of unique identifier of objects to retrieve
+   * @param attributesToRetrieve the list of attributes to retrieve for these objects
+   * @return the list of objects
+   * @throws AlgoliaException
+   */
+  default List<T> getObjects(@Nonnull List<String> objectIDs, @Nonnull List<String> attributesToRetrieve) throws AlgoliaException {
+    return getApiClient().getObjects(getName(), objectIDs, attributesToRetrieve, getKlass());
+  }
+
+  /**
+   * Override the content of object
+   *
+   * @param objectID the unique identifier of the object to retrieve
+   * @param object   the object to update
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default Task saveObject(@Nonnull String objectID, @Nonnull T object) throws AlgoliaException {
+    return getApiClient().saveObject(getName(), objectID, object);
+  }
+
+  /**
+   * Override the content the list of objects
+   *
+   * @param objects the list objects to update
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default TaskSingleIndex saveObjects(@Nonnull List<T> objects) throws AlgoliaException {
+    return getApiClient().saveObjects(getName(), objects);
+  }
+
+  /**
+   * Delete an object from the index
+   *
+   * @param objectID the unique identifier of the object to retrieve
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default Task deleteObject(@Nonnull String objectID) throws AlgoliaException {
+    return getApiClient().deleteObject(getName(), objectID);
+  }
+
+  /**
+   * Delete objects from the index
+   *
+   * @param objectIDs the list of unique identifier of the object to retrieve
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default TaskSingleIndex deleteObjects(@Nonnull List<String> objectIDs) throws AlgoliaException {
+    return getApiClient().deleteObjects(getName(), objectIDs);
+  }
+
+}
+
+interface Settings<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Get settings of this index
+   *
+   * @return the settings
+   * @throws AlgoliaException
+   */
+  default IndexSettings getSettings() throws AlgoliaException {
+    return getApiClient().getSettings(getName());
+  }
+
+  /**
+   * Set settings of this index, and do not forward to slaves
+   *
+   * @param settings the settings to set
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default Task setSettings(@Nonnull IndexSettings settings) throws AlgoliaException {
+    return setSettings(settings, false);
+  }
+
+  /**
+   * Set settings of this index
+   *
+   * @param settings          the settings to set
+   * @param forwardToReplicas should these updates be forwarded to the slaves
+   * @return the related Task
+   * @throws AlgoliaException
+   */
+  default Task setSettings(@Nonnull IndexSettings settings, @Nonnull Boolean forwardToReplicas) throws AlgoliaException {
+    return getApiClient().setSettings(getName(), settings, forwardToReplicas);
+  }
+
+}
+
+interface Key<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Deprecated: use listApiKeys
+   */
+  @Deprecated
+  default List<ApiKey> listKeys() throws AlgoliaException {
+    return listApiKeys();
+  }
+
+  /**
+   * List keys of this index
+   *
+   * @return the list of keys
+   * @throws AlgoliaException
+   */
+  default List<ApiKey> listApiKeys() throws AlgoliaException {
+    return getApiClient().listKeys(getName());
+  }
+
+  /**
+   * Deprecated: use getApiKey
+   */
+  @Deprecated
+  default Optional<ApiKey> getKey(@Nonnull String key) throws AlgoliaException {
+    return getApiKey(key);
+  }
+
+  /**
+   * Get a key by name from this index
+   *
+   * @param key the key name
+   * @return the key
+   * @throws AlgoliaException
+   */
+  default Optional<ApiKey> getApiKey(@Nonnull String key) throws AlgoliaException {
+    return getApiClient().getKey(getName(), key);
+  }
+
+  /**
+   * Deprecated: use deleteApiKey
+   */
+  @Deprecated
+  default DeleteKey deleteKey(@Nonnull String key) throws AlgoliaException {
+    return deleteApiKey(key);
+  }
+
+  /**
+   * Delete a key by name from this index
+   *
+   * @param key the key name
+   * @return the deleted key
+   * @throws AlgoliaException
+   */
+  default DeleteKey deleteApiKey(@Nonnull String key) throws AlgoliaException {
+    return getApiClient().deleteKey(getName(), key);
+  }
+
+  /**
+   * Deprecated: use addApiKey
+   */
+  @Deprecated
+  default CreateUpdateKey addKey(@Nonnull ApiKey key) throws AlgoliaException {
+    return addApiKey(key);
+  }
+
+  /**
+   * Add a key to this index
+   *
+   * @param key the key
+   * @return the created key
+   * @throws AlgoliaException
+   */
+  default CreateUpdateKey addApiKey(@Nonnull ApiKey key) throws AlgoliaException {
+    return getApiClient().addKey(getName(), key);
+  }
+
+  /**
+   * Update a key by name from this index
+   *
+   * @param keyName the key name
+   * @param key     the key to update
+   * @return the updated key
+   * @throws AlgoliaException
+   */
+  default CreateUpdateKey updateKey(@Nonnull String keyName, @Nonnull ApiKey key) throws AlgoliaException {
+    return getApiClient().updateKey(getName(), keyName, key);
+  }
+
+}
+
+interface SearchForFacet<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Search in a facet
+   * throws a {@link com.algolia.search.exceptions.AlgoliaIndexNotFoundException} if the index does not exists
+   *
+   * @param facetName  The name of the facet to search in
+   * @param facetQuery The search query for this facet
+   * @param query      the query (not required)
+   * @return the result of the search
+   * @throws AlgoliaException
+   */
+  default SearchFacetResult searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) throws AlgoliaException {
+    return getApiClient().searchForFacetValues(getName(), facetName, facetQuery, query);
+  }
+
+  /**
+   * Search in a facet
+   * throws a {@link com.algolia.search.exceptions.AlgoliaIndexNotFoundException} if the index does not exists
+   *
+   * @param facetName  The name of the facet to search in
+   * @param facetQuery The search query for this facet
+   * @return the result of the search
+   * @throws AlgoliaException
+   */
+  default SearchFacetResult searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) throws AlgoliaException {
+    return this.searchForFacetValues(facetName, facetQuery, null);
+  }
+
+  @Deprecated
+  default SearchFacetResult searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) throws AlgoliaException {
+    return this.searchForFacetValues(facetName, facetQuery, query);
+  }
+
+  @Deprecated
+  default SearchFacetResult searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) throws AlgoliaException {
+    return this.searchForFacetValues(facetName, facetQuery, null);
+  }
+
+  @Deprecated
+  default SearchFacetResult searchFacet(@Nonnull String facetName, @Nonnull String facetQuery, Query query) throws AlgoliaException {
+    return this.searchForFacetValues(facetName, facetQuery, query);
+  }
+
+  @Deprecated
+  default SearchFacetResult searchFacet(@Nonnull String facetName, @Nonnull String facetQuery) throws AlgoliaException {
+    return this.searchForFacetValues(facetName, facetQuery);
+  }
+
+}
+
+interface PartialUpdate<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Partially update an object
+   *
+   * @param objectID the ID of object to update
+   * @param object   the object to update
+   * @return the associated task
+   * @throws AlgoliaException
+   * @see PartialUpdateOperation & subclasses
+   */
+  default TaskSingleIndex partialUpdateObject(@Nonnull String objectID, @Nonnull Object object) throws AlgoliaException {
+    return getApiClient().partialUpdateObject(getName(), objectID, object);
+  }
+
+  /**
+   * Partially update a objects
+   *
+   * @param objects the list of objects to update (with an objectID)
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default TaskSingleIndex partialUpdateObjects(@Nonnull List<Object> objects) throws AlgoliaException {
+    return getApiClient().partialUpdateObjects(getName(), objects);
+  }
+
+  /**
+   * Partially update an object, create the object if it does not exist
+   *
+   * @param operation the operation to perform on this object
+   * @return the associated task
+   * @throws AlgoliaException
+   * @see PartialUpdateOperation & subclasses
+   */
+  default TaskSingleIndex partialUpdateObject(@Nonnull PartialUpdateOperation operation) throws AlgoliaException {
+    return partialUpdateObject(operation, true);
+  }
+
+  /**
+   * Partially update an object
+   *
+   * @param operation         the operation to perform on this object
+   * @param createIfNotExists should the object be created or not
+   * @return the associated task
+   * @throws AlgoliaException
+   * @see PartialUpdateOperation & subclasses
+   */
+  default TaskSingleIndex partialUpdateObject(@Nonnull PartialUpdateOperation operation, boolean createIfNotExists) throws AlgoliaException {
+    return getApiClient().partialUpdateObject(getName(), operation, createIfNotExists);
+  }
+
+}
+
+interface Synonyms<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Saves/updates a synonym without replacing it and NOT forwarding it to the slaves
+   *
+   * @param synonymID the id of the synonym
+   * @param content   the synonym
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content) throws AlgoliaException {
+    return saveSynonym(synonymID, content, false);
+  }
+
+  /**
+   * Saves/updates a synonym without replacing
+   *
+   * @param synonymID         the id of the synonym
+   * @param content           the synonym
+   * @param forwardToReplicas should this request be forwarded to slaves
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas) throws AlgoliaException {
+    return saveSynonym(synonymID, content, forwardToReplicas, false);
+  }
+
+  /**
+   * Saves/updates a synonym
+   *
+   * @param synonymID               the id of the synonym
+   * @param content                 the synonym
+   * @param forwardToReplicas       should this request be forwarded to slaves
+   * @param replaceExistingSynonyms should replace if this synonyms exists
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas, boolean replaceExistingSynonyms) throws AlgoliaException {
+    return getApiClient().saveSynonym(getName(), synonymID, content, forwardToReplicas, replaceExistingSynonyms);
+  }
+
+  /**
+   * Get a synonym by ID
+   *
+   * @param synonymID the id of the synonym
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Optional<AbstractSynonym> getSynonym(@Nonnull String synonymID) throws AlgoliaException {
+    return getApiClient().getSynonym(getName(), synonymID);
+  }
+
+  /**
+   * Deletes a synonym by ID and NOT forwarding it to the slaves
+   *
+   * @param synonymID the id of the synonym
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task deleteSynonym(@Nonnull String synonymID) throws AlgoliaException {
+    return deleteSynonym(synonymID, false);
+  }
+
+  /**
+   * Deletes a synonym
+   *
+   * @param synonymID         the id of the synonym
+   * @param forwardToReplicas should this request be forwarded to slaves
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task deleteSynonym(@Nonnull String synonymID, boolean forwardToReplicas) throws AlgoliaException {
+    return getApiClient().deleteSynonym(getName(), synonymID, forwardToReplicas);
+  }
+
+  /**
+   * Clear all synonyms and NOT forwarding it to the slaves
+   *
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task clearSynonyms() throws AlgoliaException {
+    return clearSynonyms(false);
+  }
+
+  /**
+   * Clears all synonyms
+   *
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task clearSynonyms(boolean forwardToReplicas) throws AlgoliaException {
+    return getApiClient().clearSynonyms(getName(), forwardToReplicas);
+  }
+
+  /**
+   * Search for synonyms
+   *
+   * @param query the query
+   * @return the results of the query
+   * @throws AlgoliaException
+   */
+  default SearchSynonymResult searchSynonyms(@Nonnull SynonymQuery query) throws AlgoliaException {
+    return getApiClient().searchSynonyms(getName(), query);
+  }
+
+  /**
+   * Add or Replace a list of synonyms
+   *
+   * @param synonyms                List of synonyms
+   * @param forwardToReplicas       Forward the operation to the slave indices
+   * @param replaceExistingSynonyms Replace the existing synonyms with this batch
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas, boolean replaceExistingSynonyms) throws AlgoliaException {
+    return getApiClient().batchSynonyms(getName(), synonyms, forwardToReplicas, replaceExistingSynonyms);
+  }
+
+  /**
+   * Add or Replace a list of synonyms, no replacement
+   *
+   * @param synonyms          List of synonyms
+   * @param forwardToReplicas Forward the operation to the slave indices
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas) throws AlgoliaException {
+    return batchSynonyms(synonyms, forwardToReplicas, false);
+  }
+
+  /**
+   * Add or Replace a list of synonyms, no forward to slaves, and no replacement
+   *
+   * @param synonyms List of synonyms
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms) throws AlgoliaException {
+    return batchSynonyms(synonyms, false, false);
+  }
+
+}
+
+interface Browse<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Browse all the content of this index
+   *
+   * @param query The query to use to browse
+   * @return the iterator on top of this index
+   * @throws AlgoliaException
+   */
+  default IndexIterable<T> browse(@Nonnull Query query) throws AlgoliaException {
+    return new IndexIterable<>(getApiClient(), getName(), query, getKlass());
+  }
+
+  /**
+   * Browse all the content of this index
+   *
+   * @param query  The query to use to browse
+   * @param cursor the cursor to start from
+   * @return the iterator on top of this index
+   * @throws AlgoliaException
+   */
+  default IndexIterable<T> browseFrom(@Nonnull Query query, @Nullable String cursor) throws AlgoliaException {
+    return new IndexIterable<>(getApiClient(), getName(), query, cursor, getKlass());
+  }
+
+}
+
+interface DeleteByQuery<T> extends BaseSyncIndex<T> {
+
+  /**
+   * Delete records matching a query, with a batch size of 1000, internally uses browse
+   *
+   * @param query The query
+   * @throws AlgoliaException
+   */
+  default void deleteByQuery(@Nonnull Query query) throws AlgoliaException {
+    getApiClient().deleteByQuery(getName(), query, 1000);
+  }
+
+  /**
+   * Delete records matching a query, internally uses browse
+   *
+   * @param query     The query
+   * @param batchSize the size of the batches
+   * @throws AlgoliaException
+   */
+  default void deleteByQuery(@Nonnull Query query, int batchSize) throws AlgoliaException {
+    getApiClient().deleteByQuery(getName(), query, batchSize);
+  }
+
+}
+
 @SuppressWarnings("WeakerAccess")
-public class Index<T> extends AbstractIndex<T> {
+public class Index<T> implements
+  DeleteByQuery<T>,
+  Browse<T>,
+  Synonyms<T>,
+  PartialUpdate<T>,
+  SearchForFacet<T>,
+  Key<T>,
+  Settings<T>,
+  Objects<T>,
+  Tasks<T>,
+  IndexCRUD<T> {
 
   /**
    * Index name
@@ -48,303 +683,9 @@ public class Index<T> extends AbstractIndex<T> {
     return klass;
   }
 
-  /**
-   * Add an object in this index
-   *
-   * @param object object to add
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public TaskIndexing addObject(@Nonnull T object) throws AlgoliaException {
-    return client.addObject(name, object);
-  }
-
-  /**
-   * Add an object in this index with a unique identifier
-   *
-   * @param objectID the objectID associated to this object
-   *                 (if this objectID already exist the old object will be overridden)
-   * @param object   object to add
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public TaskIndexing addObject(@Nonnull String objectID, @Nonnull T object) throws AlgoliaException {
-    return client.addObject(name, objectID, object);
-  }
-
-  /**
-   * Add several objects
-   *
-   * @param objects objects to add
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public TaskSingleIndex addObjects(@Nonnull List<T> objects) throws AlgoliaException {
-    return client.addObjects(name, objects);
-  }
-
-  /**
-   * Get an object from this index
-   *
-   * @param objectID the unique identifier of the object to retrieve
-   * @return The object
-   * @throws AlgoliaException
-   */
-  public Optional<T> getObject(@Nonnull String objectID) throws AlgoliaException {
-    return client.getObject(name, objectID, klass);
-  }
-
-  /**
-   * Get several objects from this index
-   *
-   * @param objectIDs the list of unique identifier of objects to retrieve
-   * @return the list of objects
-   * @throws AlgoliaException
-   */
-  public List<T> getObjects(@Nonnull List<String> objectIDs) throws AlgoliaException {
-    return client.getObjects(name, objectIDs, klass);
-  }
-
-  /**
-   * Get several objects from this index
-   *
-   * @param objectIDs            the list of unique identifier of objects to retrieve
-   * @param attributesToRetrieve the list of attributes to retrieve for these objects
-   * @return the list of objects
-   * @throws AlgoliaException
-   */
-  public List<T> getObjects(@Nonnull List<String> objectIDs, @Nonnull List<String> attributesToRetrieve) throws AlgoliaException {
-    return client.getObjects(name, objectIDs, attributesToRetrieve, klass);
-  }
-
-  /**
-   * Wait for the completion of a task
-   *
-   * @param task       task to wait for
-   * @param timeToWait the time to wait in milliseconds
-   * @throws AlgoliaException
-   */
-  public void waitTask(@Nonnull Task task, long timeToWait) throws AlgoliaException {
-    Preconditions.checkArgument(timeToWait >= 0, "timeToWait must be >= 0, was %s", timeToWait);
-
-    client.waitTask(task, timeToWait);
-  }
-
-  /**
-   * Wait for the completion of a task, for 100ms
-   *
-   * @param task task to wait for
-   * @throws AlgoliaException
-   */
-  public void waitTask(@Nonnull Task task) throws AlgoliaException {
-    client.waitTask(task, 100);
-  }
-
-  /**
-   * Deletes the index
-   *
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public Task delete() throws AlgoliaException {
-    return client.deleteIndex(name);
-  }
-
-  /**
-   * Delete the index content without removing settings and index specific API keys.
-   *
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public Task clear() throws AlgoliaException {
-    return client.clearIndex(name);
-  }
-
-  /**
-   * Override the content of object
-   *
-   * @param objectID the unique identifier of the object to retrieve
-   * @param object   the object to update
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public Task saveObject(@Nonnull String objectID, @Nonnull T object) throws AlgoliaException {
-    return client.saveObject(name, objectID, object);
-  }
-
-  /**
-   * Override the content the list of objects
-   *
-   * @param objects the list objects to update
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public TaskSingleIndex saveObjects(@Nonnull List<T> objects) throws AlgoliaException {
-    return client.saveObjects(name, objects);
-  }
-
-  /**
-   * Delete an object from the index
-   *
-   * @param objectID the unique identifier of the object to retrieve
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public Task deleteObject(@Nonnull String objectID) throws AlgoliaException {
-    return client.deleteObject(name, objectID);
-  }
-
-  /**
-   * Delete objects from the index
-   *
-   * @param objectIDs the list of unique identifier of the object to retrieve
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public TaskSingleIndex deleteObjects(@Nonnull List<String> objectIDs) throws AlgoliaException {
-    return client.deleteObjects(name, objectIDs);
-  }
-
-  /**
-   * Get settings of this index
-   *
-   * @return the settings
-   * @throws AlgoliaException
-   */
-  public IndexSettings getSettings() throws AlgoliaException {
-    return client.getSettings(name);
-  }
-
-  /**
-   * Set settings of this index, and do not forward to slaves
-   *
-   * @param settings the settings to set
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public Task setSettings(@Nonnull IndexSettings settings) throws AlgoliaException {
-    return setSettings(settings, false);
-  }
-
-  /**
-   * Set settings of this index
-   *
-   * @param settings          the settings to set
-   * @param forwardToReplicas should these updates be forwarded to the slaves
-   * @return the related Task
-   * @throws AlgoliaException
-   */
-  public Task setSettings(@Nonnull IndexSettings settings, @Nonnull Boolean forwardToReplicas) throws AlgoliaException {
-    return client.setSettings(name, settings, forwardToReplicas);
-  }
-
-  /**
-   * Deprecated: use listApiKeys
-   */
-  @Deprecated
-  public List<ApiKey> listKeys() throws AlgoliaException {
-    return listApiKeys();
-  }
-
-  /**
-   * List keys of this index
-   *
-   * @return the list of keys
-   * @throws AlgoliaException
-   */
-  public List<ApiKey> listApiKeys() throws AlgoliaException {
-    return client.listKeys(name);
-  }
-
-  /**
-   * Deprecated: use getApiKey
-   */
-  @Deprecated
-  public Optional<ApiKey> getKey(@Nonnull String key) throws AlgoliaException {
-    return getApiKey(key);
-  }
-
-  /**
-   * Get a key by name from this index
-   *
-   * @param key the key name
-   * @return the key
-   * @throws AlgoliaException
-   */
-  public Optional<ApiKey> getApiKey(@Nonnull String key) throws AlgoliaException {
-    return client.getKey(name, key);
-  }
-
-  /**
-   * Deprecated: use deleteApiKey
-   */
-  @Deprecated
-  public DeleteKey deleteKey(@Nonnull String key) throws AlgoliaException {
-    return deleteApiKey(key);
-  }
-
-  /**
-   * Delete a key by name from this index
-   *
-   * @param key the key name
-   * @return the deleted key
-   * @throws AlgoliaException
-   */
-  public DeleteKey deleteApiKey(@Nonnull String key) throws AlgoliaException {
-    return client.deleteKey(name, key);
-  }
-
-  /**
-   * Deprecated: use addApiKey
-   */
-  @Deprecated
-  public CreateUpdateKey addKey(@Nonnull ApiKey key) throws AlgoliaException {
-    return addApiKey(key);
-  }
-
-  /**
-   * Add a key to this index
-   *
-   * @param key the key
-   * @return the created key
-   * @throws AlgoliaException
-   */
-  public CreateUpdateKey addApiKey(@Nonnull ApiKey key) throws AlgoliaException {
-    return client.addKey(name, key);
-  }
-
-  /**
-   * Update a key by name from this index
-   *
-   * @param keyName the key name
-   * @param key     the key to update
-   * @return the updated key
-   * @throws AlgoliaException
-   */
-  public CreateUpdateKey updateKey(@Nonnull String keyName, @Nonnull ApiKey key) throws AlgoliaException {
-    return client.updateKey(name, keyName, key);
-  }
-
-  /**
-   * Moves an existing index
-   *
-   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overriten if it already exist)
-   * @return The task associated
-   * @throws AlgoliaException
-   */
-  public Task moveTo(@Nonnull String dstIndexName) throws AlgoliaException {
-    return client.moveIndex(name, dstIndexName);
-  }
-
-  /**
-   * Copy an existing index
-   *
-   * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overridden if it already exist)
-   * @return The task associated
-   * @throws AlgoliaException
-   */
-  public Task copyTo(@Nonnull String dstIndexName) throws AlgoliaException {
-    return client.copyIndex(name, dstIndexName);
+  @Override
+  public APIClient getApiClient() {
+    return client;
   }
 
   /**
@@ -360,53 +701,6 @@ public class Index<T> extends AbstractIndex<T> {
   }
 
   /**
-   * Search in a facet
-   * throws a {@link com.algolia.search.exceptions.AlgoliaIndexNotFoundException} if the index does not exists
-   *
-   * @param facetName  The name of the facet to search in
-   * @param facetQuery The search query for this facet
-   * @param query      the query (not required)
-   * @return the result of the search
-   * @throws AlgoliaException
-   */
-  public SearchFacetResult searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) throws AlgoliaException {
-    return client.searchForFacetValues(name, facetName, facetQuery, query);
-  }
-
-  /**
-   * Search in a facet
-   * throws a {@link com.algolia.search.exceptions.AlgoliaIndexNotFoundException} if the index does not exists
-   *
-   * @param facetName  The name of the facet to search in
-   * @param facetQuery The search query for this facet
-   * @return the result of the search
-   * @throws AlgoliaException
-   */
-  public SearchFacetResult searchForFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) throws AlgoliaException {
-    return this.searchForFacetValues(facetName, facetQuery, null);
-  }
-
-  @Deprecated
-  public SearchFacetResult searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery, Query query) throws AlgoliaException {
-    return this.searchForFacetValues(facetName, facetQuery, query);
-  }
-
-  @Deprecated
-  public SearchFacetResult searchInFacetValues(@Nonnull String facetName, @Nonnull String facetQuery) throws AlgoliaException {
-    return this.searchForFacetValues(facetName, facetQuery, null);
-  }
-
-  @Deprecated
-  public SearchFacetResult searchFacet(@Nonnull String facetName, @Nonnull String facetQuery, Query query) throws AlgoliaException {
-    return this.searchForFacetValues(facetName, facetQuery, query);
-  }
-
-  @Deprecated
-  public SearchFacetResult searchFacet(@Nonnull String facetName, @Nonnull String facetQuery) throws AlgoliaException {
-    return this.searchForFacetValues(facetName, facetQuery);
-  }
-
-  /**
    * Custom batch
    * <p>
    * All operations must have index name set to <code>null</code>
@@ -418,239 +712,6 @@ public class Index<T> extends AbstractIndex<T> {
    */
   public TaskSingleIndex batch(@Nonnull List<BatchOperation> operations) throws AlgoliaException {
     return client.batch(name, operations);
-  }
-
-  /**
-   * Partially update an object
-   *
-   * @param objectID the ID of object to update
-   * @param object   the object to update
-   * @return the associated task
-   * @throws AlgoliaException
-   * @see PartialUpdateOperation & subclasses
-   */
-  public TaskSingleIndex partialUpdateObject(@Nonnull String objectID, @Nonnull Object object) throws AlgoliaException {
-    return client.partialUpdateObject(name, objectID, object);
-  }
-
-  /**
-   * Partially update a objects
-   *
-   * @param objects the list of objects to update (with an objectID)
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public TaskSingleIndex partialUpdateObjects(@Nonnull List<Object> objects) throws AlgoliaException {
-    return client.partialUpdateObjects(name, objects);
-  }
-
-  /**
-   * Partially update an object, create the object if it does not exist
-   *
-   * @param operation the operation to perform on this object
-   * @return the associated task
-   * @throws AlgoliaException
-   * @see PartialUpdateOperation & subclasses
-   */
-  public TaskSingleIndex partialUpdateObject(@Nonnull PartialUpdateOperation operation) throws AlgoliaException {
-    return partialUpdateObject(operation, true);
-  }
-
-  /**
-   * Partially update an object
-   *
-   * @param operation         the operation to perform on this object
-   * @param createIfNotExists should the object be created or not
-   * @return the associated task
-   * @throws AlgoliaException
-   * @see PartialUpdateOperation & subclasses
-   */
-  public TaskSingleIndex partialUpdateObject(@Nonnull PartialUpdateOperation operation, boolean createIfNotExists) throws AlgoliaException {
-    return client.partialUpdateObject(name, operation, createIfNotExists);
-  }
-
-  /**
-   * Saves/updates a synonym without replacing it and NOT forwarding it to the slaves
-   *
-   * @param synonymID the id of the synonym
-   * @param content   the synonym
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content) throws AlgoliaException {
-    return saveSynonym(synonymID, content, false);
-  }
-
-  /**
-   * Saves/updates a synonym without replacing
-   *
-   * @param synonymID         the id of the synonym
-   * @param content           the synonym
-   * @param forwardToReplicas should this request be forwarded to slaves
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas) throws AlgoliaException {
-    return saveSynonym(synonymID, content, forwardToReplicas, false);
-  }
-
-  /**
-   * Saves/updates a synonym
-   *
-   * @param synonymID               the id of the synonym
-   * @param content                 the synonym
-   * @param forwardToReplicas       should this request be forwarded to slaves
-   * @param replaceExistingSynonyms should replace if this synonyms exists
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas, boolean replaceExistingSynonyms) throws AlgoliaException {
-    return client.saveSynonym(name, synonymID, content, forwardToReplicas, replaceExistingSynonyms);
-  }
-
-  /**
-   * Get a synonym by ID
-   *
-   * @param synonymID the id of the synonym
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Optional<AbstractSynonym> getSynonym(@Nonnull String synonymID) throws AlgoliaException {
-    return client.getSynonym(name, synonymID);
-  }
-
-  /**
-   * Deletes a synonym by ID and NOT forwarding it to the slaves
-   *
-   * @param synonymID the id of the synonym
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task deleteSynonym(@Nonnull String synonymID) throws AlgoliaException {
-    return deleteSynonym(synonymID, false);
-  }
-
-  /**
-   * Deletes a synonym
-   *
-   * @param synonymID         the id of the synonym
-   * @param forwardToReplicas should this request be forwarded to slaves
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task deleteSynonym(@Nonnull String synonymID, boolean forwardToReplicas) throws AlgoliaException {
-    return client.deleteSynonym(name, synonymID, forwardToReplicas);
-  }
-
-  /**
-   * Clear all synonyms and NOT forwarding it to the slaves
-   *
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task clearSynonyms() throws AlgoliaException {
-    return clearSynonyms(false);
-  }
-
-  /**
-   * Clears all synonyms
-   *
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task clearSynonyms(boolean forwardToReplicas) throws AlgoliaException {
-    return client.clearSynonyms(name, forwardToReplicas);
-  }
-
-  /**
-   * Search for synonyms
-   *
-   * @param query the query
-   * @return the results of the query
-   * @throws AlgoliaException
-   */
-  public SearchSynonymResult searchSynonyms(@Nonnull SynonymQuery query) throws AlgoliaException {
-    return client.searchSynonyms(name, query);
-  }
-
-  /**
-   * Add or Replace a list of synonyms
-   *
-   * @param synonyms                List of synonyms
-   * @param forwardToReplicas       Forward the operation to the slave indices
-   * @param replaceExistingSynonyms Replace the existing synonyms with this batch
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas, boolean replaceExistingSynonyms) throws AlgoliaException {
-    return client.batchSynonyms(name, synonyms, forwardToReplicas, replaceExistingSynonyms);
-  }
-
-  /**
-   * Add or Replace a list of synonyms, no replacement
-   *
-   * @param synonyms          List of synonyms
-   * @param forwardToReplicas Forward the operation to the slave indices
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas) throws AlgoliaException {
-    return batchSynonyms(synonyms, forwardToReplicas, false);
-  }
-
-  /**
-   * Add or Replace a list of synonyms, no forward to slaves, and no replacement
-   *
-   * @param synonyms List of synonyms
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  public Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms) throws AlgoliaException {
-    return batchSynonyms(synonyms, false, false);
-  }
-
-  /**
-   * Browse all the content of this index
-   *
-   * @param query The query to use to browse
-   * @return the iterator on top of this index
-   * @throws AlgoliaException
-   */
-  public IndexIterable<T> browse(@Nonnull Query query) throws AlgoliaException {
-    return new IndexIterable<>(client, name, query, klass);
-  }
-
-  /**
-   * Browse all the content of this index
-   *
-   * @param query  The query to use to browse
-   * @param cursor the cursor to start from
-   * @return the iterator on top of this index
-   * @throws AlgoliaException
-   */
-  public IndexIterable<T> browseFrom(@Nonnull Query query, @Nullable String cursor) throws AlgoliaException {
-    return new IndexIterable<>(client, name, query, cursor, klass);
-  }
-
-  /**
-   * Delete records matching a query, with a batch size of 1000, internally uses browse
-   *
-   * @param query The query
-   * @throws AlgoliaException
-   */
-  public void deleteByQuery(@Nonnull Query query) throws AlgoliaException {
-    client.deleteByQuery(name, query, 1000);
-  }
-
-  /**
-   * Delete records matching a query, internally uses browse
-   *
-   * @param query     The query
-   * @param batchSize the size of the batches
-   * @throws AlgoliaException
-   */
-  public void deleteByQuery(@Nonnull Query query, int batchSize) throws AlgoliaException {
-    client.deleteByQuery(name, query, batchSize);
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
This PR only improves readability for the maintainers. 
It's a step before implementing the query rules