### PR TITLE
fix(partialupdate): Fix partial update objects with createIfNotExists

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.15.4 (2017-12-1)
+-------------------
+- Add partialUpdateObjects with createIfNotExists
+
 2.15.3 (2017-12-07)
 -------------------
 - Fix deserialization with specific object mapper

--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -8,8 +8,8 @@ import com.algolia.search.http.HttpMethod;
 import com.algolia.search.inputs.*;
 import com.algolia.search.inputs.batch.BatchAddObjectOperation;
 import com.algolia.search.inputs.batch.BatchDeleteObjectOperation;
-import com.algolia.search.inputs.batch.BatchPartialUpdateObjectOperation;
 import com.algolia.search.inputs.batch.BatchPartialUpdateObjectNoCreateOperation;
+import com.algolia.search.inputs.batch.BatchPartialUpdateObjectOperation;
 import com.algolia.search.inputs.batch.BatchUpdateObjectOperation;
 import com.algolia.search.inputs.partial_update.PartialUpdateOperation;
 import com.algolia.search.inputs.query_rules.Rule;
@@ -1086,16 +1086,22 @@ public class APIClient {
   }
 
   TaskSingleIndex partialUpdateObjects(
-          String indexName, List<Object> objects, RequestOptions requestOptions, boolean createIfNotExists)
-          throws AlgoliaException {
+      String indexName,
+      List<Object> objects,
+      RequestOptions requestOptions,
+      boolean createIfNotExists)
+      throws AlgoliaException {
     TaskSingleIndex task =
-            batch(
-                    indexName,
-                    objects
-                            .stream()
-                            .map(createIfNotExists ? BatchPartialUpdateObjectOperation::new : BatchPartialUpdateObjectNoCreateOperation::new)
-                            .collect(Collectors.toList()),
-                    requestOptions);
+        batch(
+            indexName,
+            objects
+                .stream()
+                .map(
+                    createIfNotExists
+                        ? BatchPartialUpdateObjectOperation::new
+                        : BatchPartialUpdateObjectNoCreateOperation::new)
+                .collect(Collectors.toList()),
+            requestOptions);
 
     return task.setAPIClient(this).setIndex(indexName);
   }

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -8,8 +8,8 @@ import com.algolia.search.http.HttpMethod;
 import com.algolia.search.inputs.*;
 import com.algolia.search.inputs.batch.BatchAddObjectOperation;
 import com.algolia.search.inputs.batch.BatchDeleteObjectOperation;
-import com.algolia.search.inputs.batch.BatchPartialUpdateObjectOperation;
 import com.algolia.search.inputs.batch.BatchPartialUpdateObjectNoCreateOperation;
+import com.algolia.search.inputs.batch.BatchPartialUpdateObjectOperation;
 import com.algolia.search.inputs.batch.BatchUpdateObjectOperation;
 import com.algolia.search.inputs.partial_update.PartialUpdateOperation;
 import com.algolia.search.inputs.query_rules.Rule;
@@ -1041,15 +1041,21 @@ public class AsyncAPIClient {
   }
 
   CompletableFuture<AsyncTaskSingleIndex> partialUpdateObjects(
-          String indexName, List<Object> objects, RequestOptions requestOptions, boolean createIfNotExists) {
+      String indexName,
+      List<Object> objects,
+      RequestOptions requestOptions,
+      boolean createIfNotExists) {
     return batch(
             indexName,
             objects
-                    .stream()
-                    .map(createIfNotExists ? BatchPartialUpdateObjectOperation::new : BatchPartialUpdateObjectNoCreateOperation::new)
-                    .collect(Collectors.toList()),
+                .stream()
+                .map(
+                    createIfNotExists
+                        ? BatchPartialUpdateObjectOperation::new
+                        : BatchPartialUpdateObjectNoCreateOperation::new)
+                .collect(Collectors.toList()),
             requestOptions)
-            .thenApply(s -> s.setIndex(indexName));
+        .thenApply(s -> s.setIndex(indexName));
   }
 
   CompletableFuture<SearchFacetResult> searchForFacetValues(

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndex.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndex.java
@@ -1,5 +1,6 @@
 package com.algolia.search;
 
+import com.algolia.search.exceptions.AlgoliaException;
 import com.algolia.search.inputs.BatchOperation;
 import com.algolia.search.inputs.partial_update.PartialUpdateOperation;
 import com.algolia.search.inputs.query_rules.Rule;
@@ -769,6 +770,24 @@ interface AsyncPartialUpdate<T> extends BaseAsyncIndex<T> {
   default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObjects(
       @Nonnull List<Object> objects, @Nonnull RequestOptions requestOptions) {
     return getApiClient().partialUpdateObjects(getName(), objects, requestOptions);
+  }
+
+  /**
+   * Partially update a objects
+   *
+   * @param objects the list of objects to update (with an objectID)
+   * @param createIfNotExists Value that indicates the object is created if the objectID doesn't
+   *     exists
+   * @param requestOptions Options to pass to this request
+   * @return the associated task
+   * @throws AlgoliaException
+   */
+  default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObjects(
+      @Nonnull List<Object> objects,
+      boolean createIfNotExists,
+      @Nonnull RequestOptions requestOptions) {
+    return getApiClient()
+        .partialUpdateObjects(getName(), objects, requestOptions, createIfNotExists);
   }
 
   /**

--- a/algoliasearch-common/src/main/java/com/algolia/search/Index.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/Index.java
@@ -843,7 +843,7 @@ interface PartialUpdate<T> extends BaseSyncIndex<T> {
   default TaskSingleIndex partialUpdateObjects(
       @Nonnull List<Object> objects, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
-    return partialUpdateObjects(objects, requestOptions, true);
+    return partialUpdateObjects(objects, true, requestOptions);
   }
 
   /**
@@ -851,14 +851,18 @@ interface PartialUpdate<T> extends BaseSyncIndex<T> {
    *
    * @param objects the list of objects to update (with an objectID)
    * @param requestOptions Options to pass to this request
-   * @param createIfNotExists Value that indicates the object is created if the objectID doesn't exists
+   * @param createIfNotExists Value that indicates the object is created if the objectID doesn't
+   *     exists
    * @return the associated task
    * @throws AlgoliaException
    */
   default TaskSingleIndex partialUpdateObjects(
-          @Nonnull List<Object> objects, @Nonnull RequestOptions requestOptions, boolean createIfNotExists)
-          throws AlgoliaException {
-    return getApiClient().partialUpdateObjects(getName(), objects, requestOptions, createIfNotExists);
+      @Nonnull List<Object> objects,
+      boolean createIfNotExists,
+      @Nonnull RequestOptions requestOptions)
+      throws AlgoliaException {
+    return getApiClient()
+        .partialUpdateObjects(getName(), objects, requestOptions, createIfNotExists);
   }
 
   /**


### PR DESCRIPTION
cc: @robertmogos, @PLNech.

The previous PR missed the method in `AsyncIndex`, the formatting, and the parameter `RequestOptions` is always the last one