### PR TITLE
fix(synonyms): Remove `replaceExistingSynonyms` from `saveSynonym`

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -959,7 +959,6 @@ public class APIClient {
       String synonymID,
       AbstractSynonym content,
       Boolean forwardToReplicas,
-      Boolean replaceExistingSynonyms,
       RequestOptions requestOptions)
       throws AlgoliaException {
     Task task =
@@ -970,12 +969,7 @@ public class APIClient {
                     Arrays.asList("1", "indexes", indexName, "synonyms", synonymID),
                     requestOptions,
                     Task.class)
-                .setParameters(
-                    ImmutableMap.of(
-                        "forwardToReplicas",
-                        forwardToReplicas.toString(),
-                        "replaceExistingSynonyms",
-                        replaceExistingSynonyms.toString()))
+                .setParameters(ImmutableMap.of("forwardToReplicas", forwardToReplicas.toString()))
                 .setData(content));
 
     return task.setAPIClient(this).setIndex(indexName);

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -935,7 +935,6 @@ public class AsyncAPIClient {
       String synonymID,
       AbstractSynonym content,
       Boolean forwardToReplicas,
-      Boolean replaceExistingSynonyms,
       RequestOptions requestOptions) {
     return httpClient
         .requestWithRetry(
@@ -945,12 +944,7 @@ public class AsyncAPIClient {
                     Arrays.asList("1", "indexes", indexName, "synonyms", synonymID),
                     requestOptions,
                     AsyncTask.class)
-                .setParameters(
-                    ImmutableMap.of(
-                        "forwardToReplicas",
-                        forwardToReplicas.toString(),
-                        "replaceExistingSynonyms",
-                        replaceExistingSynonyms.toString()))
+                .setParameters(ImmutableMap.of("forwardToReplicas", forwardToReplicas.toString()))
                 .setData(content))
         .thenApply(s -> s.setIndex(indexName));
   }

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndex.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndex.java
@@ -868,7 +868,7 @@ interface AsyncSynonyms<T> extends BaseAsyncIndex<T> {
    */
   default CompletableFuture<AsyncTask> saveSynonym(
       @Nonnull String synonymID, @Nonnull AbstractSynonym content) {
-    return saveSynonym(synonymID, content, false);
+    return saveSynonym(synonymID, content, false, RequestOptions.empty);
   }
 
   /**
@@ -896,7 +896,7 @@ interface AsyncSynonyms<T> extends BaseAsyncIndex<T> {
    */
   default CompletableFuture<AsyncTask> saveSynonym(
       @Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas) {
-    return saveSynonym(synonymID, content, forwardToReplicas, false);
+    return saveSynonym(synonymID, content, forwardToReplicas, RequestOptions.empty);
   }
 
   /**
@@ -913,51 +913,8 @@ interface AsyncSynonyms<T> extends BaseAsyncIndex<T> {
       @Nonnull AbstractSynonym content,
       boolean forwardToReplicas,
       @Nonnull RequestOptions requestOptions) {
-    return saveSynonym(synonymID, content, forwardToReplicas, false, requestOptions);
-  }
-
-  /**
-   * Saves/updates a synonym
-   *
-   * @param synonymID the id of the synonym
-   * @param content the synonym
-   * @param forwardToReplicas should this request be forwarded to replicas
-   * @param replaceExistingSynonyms should replace if this synonyms exists
-   * @return the associated task
-   */
-  default CompletableFuture<AsyncTask> saveSynonym(
-      @Nonnull String synonymID,
-      @Nonnull AbstractSynonym content,
-      boolean forwardToReplicas,
-      boolean replaceExistingSynonyms) {
-    return saveSynonym(
-        synonymID, content, forwardToReplicas, replaceExistingSynonyms, RequestOptions.empty);
-  }
-
-  /**
-   * Saves/updates a synonym
-   *
-   * @param synonymID the id of the synonym
-   * @param content the synonym
-   * @param forwardToReplicas should this request be forwarded to slaves
-   * @param replaceExistingSynonyms should replace if this synonyms exists
-   * @param requestOptions Options to pass to this request
-   * @return the associated task
-   */
-  default CompletableFuture<AsyncTask> saveSynonym(
-      @Nonnull String synonymID,
-      @Nonnull AbstractSynonym content,
-      boolean forwardToReplicas,
-      boolean replaceExistingSynonyms,
-      @Nonnull RequestOptions requestOptions) {
     return getApiClient()
-        .saveSynonym(
-            getName(),
-            synonymID,
-            content,
-            forwardToReplicas,
-            replaceExistingSynonyms,
-            requestOptions);
+        .saveSynonym(getName(), synonymID, content, forwardToReplicas, requestOptions);
   }
 
   /**

--- a/algoliasearch-common/src/main/java/com/algolia/search/Index.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/Index.java
@@ -952,7 +952,7 @@ interface Synonyms<T> extends BaseSyncIndex<T> {
    */
   default Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content)
       throws AlgoliaException {
-    return saveSynonym(synonymID, content, false);
+    return saveSynonym(synonymID, content, false, RequestOptions.empty);
   }
 
   /**
@@ -984,7 +984,7 @@ interface Synonyms<T> extends BaseSyncIndex<T> {
   default Task saveSynonym(
       @Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas)
       throws AlgoliaException {
-    return saveSynonym(synonymID, content, forwardToReplicas, false);
+    return saveSynonym(synonymID, content, forwardToReplicas, RequestOptions.empty);
   }
 
   /**
@@ -1003,55 +1003,8 @@ interface Synonyms<T> extends BaseSyncIndex<T> {
       boolean forwardToReplicas,
       @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
-    return saveSynonym(synonymID, content, forwardToReplicas, false, requestOptions);
-  }
-
-  /**
-   * Saves/updates a synonym
-   *
-   * @param synonymID the id of the synonym
-   * @param content the synonym
-   * @param forwardToReplicas should this request be forwarded to replicas
-   * @param replaceExistingSynonyms should replace if this synonyms exists
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  default Task saveSynonym(
-      @Nonnull String synonymID,
-      @Nonnull AbstractSynonym content,
-      boolean forwardToReplicas,
-      boolean replaceExistingSynonyms)
-      throws AlgoliaException {
-    return saveSynonym(
-        synonymID, content, forwardToReplicas, replaceExistingSynonyms, RequestOptions.empty);
-  }
-
-  /**
-   * Saves/updates a synonym
-   *
-   * @param synonymID the id of the synonym
-   * @param content the synonym
-   * @param forwardToReplicas should this request be forwarded to slaves
-   * @param replaceExistingSynonyms should replace if this synonyms exists
-   * @param requestOptions Options to pass to this request
-   * @return the associated task
-   * @throws AlgoliaException
-   */
-  default Task saveSynonym(
-      @Nonnull String synonymID,
-      @Nonnull AbstractSynonym content,
-      boolean forwardToReplicas,
-      boolean replaceExistingSynonyms,
-      @Nonnull RequestOptions requestOptions)
-      throws AlgoliaException {
     return getApiClient()
-        .saveSynonym(
-            getName(),
-            synonymID,
-            content,
-            forwardToReplicas,
-            replaceExistingSynonyms,
-            requestOptions);
+        .saveSynonym(getName(), synonymID, content, forwardToReplicas, requestOptions);
   }
 
   /**

--- a/algoliasearch-tests/src/test/java/com/algolia/search/ApacheHttpClientTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/ApacheHttpClientTest.java
@@ -68,14 +68,14 @@ public class ApacheHttpClientTest {
   public void shouldHandleTimeoutsInDns() throws Exception {
     APIClient client = build("java-dsn.algolia.biz", APPLICATION_ID + "-dsn.algolia.net");
 
-    assertThatItTookLessThan(3 * 1000, () -> assertThat(client.listIndices()).isNotNull());
+    assertThatItTookLessThan(3 * 1000, () -> assertThat(client.listIndexes()).isNotNull());
   }
 
   @Test
   public void shouldHandleConnectTimeout() throws Exception {
     APIClient client = build("notcp-xx-1.algolianet.com", APPLICATION_ID + "-dsn.algolia.net");
 
-    assertThatItTookLessThan(3 * 1000, () -> assertThat(client.listIndices()).isNotNull());
+    assertThatItTookLessThan(3 * 1000, () -> assertThat(client.listIndexes()).isNotNull());
   }
 
   @Test
@@ -84,7 +84,7 @@ public class ApacheHttpClientTest {
 
     assertThatItTookLessThan(
         3 * 1000,
-        () -> assertThatExceptionOfType(AlgoliaException.class).isThrownBy(client::listIndices));
+        () -> assertThatExceptionOfType(AlgoliaException.class).isThrownBy(client::listIndexes));
   }
 
   @Test

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncBatchTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncBatchTest.java
@@ -71,7 +71,7 @@ public abstract class SyncBatchTest extends SyncAlgoliaIntegrationTest {
         .waitForCompletion();
 
     assertThat(index2.search(new Query("")).getNbHits()).isEqualTo(0);
-    assertThat(client.listIndices()).extracting("name").doesNotContain("index3");
+    assertThat(client.listIndexes()).extracting("name").doesNotContain("index3");
     assertThat(index4.getObject("1").get())
         .isEqualToComparingFieldByField(new AlgoliaObjectWithID("1", "name2", 2));
   }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncIndicesTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncIndicesTest.java
@@ -32,12 +32,12 @@ public abstract class SyncIndicesTest extends SyncAlgoliaIntegrationTest {
 
   @Test
   public void getAllIndices() throws AlgoliaException {
-    assertThat(client.listIndices()).isNotNull();
+    assertThat(client.listIndexes()).isNotNull();
 
     Index<AlgoliaObject> index = client.initIndex("index1", AlgoliaObject.class);
     index.addObject(new AlgoliaObject("algolia", 4)).waitForCompletion();
 
-    List<Index.Attributes> listIndices = client.listIndices();
+    List<Index.Attributes> listIndices = client.listIndexes();
     assertThat(listIndices).extracting("name").contains("index1");
     assertThat(listIndices).extracting("numberOfPendingTasks").isNotNull();
   }
@@ -47,10 +47,10 @@ public abstract class SyncIndicesTest extends SyncAlgoliaIntegrationTest {
     Index<AlgoliaObject> index = client.initIndex("index2", AlgoliaObject.class);
     index.addObject(new AlgoliaObject("algolia", 4)).waitForCompletion();
 
-    assertThat(client.listIndices()).extracting("name").contains("index2");
+    assertThat(client.listIndexes()).extracting("name").contains("index2");
 
     index.delete().waitForCompletion();
-    assertThat(client.listIndices()).extracting("name").doesNotContain("index2");
+    assertThat(client.listIndexes()).extracting("name").doesNotContain("index2");
   }
 
   @Test
@@ -58,10 +58,10 @@ public abstract class SyncIndicesTest extends SyncAlgoliaIntegrationTest {
     Index<AlgoliaObject> index = client.initIndex("index3", AlgoliaObject.class);
     index.addObject(new AlgoliaObject("algolia", 4)).waitForCompletion();
 
-    assertThat(client.listIndices()).extracting("name").contains("index3");
+    assertThat(client.listIndexes()).extracting("name").contains("index3");
 
     index.moveTo("index4").waitForCompletion();
-    assertThat(client.listIndices()).extracting("name").doesNotContain("index3").contains("index4");
+    assertThat(client.listIndexes()).extracting("name").doesNotContain("index3").contains("index4");
   }
 
   @Test
@@ -69,10 +69,10 @@ public abstract class SyncIndicesTest extends SyncAlgoliaIntegrationTest {
     Index<AlgoliaObject> index = client.initIndex("index5", AlgoliaObject.class);
     index.addObject(new AlgoliaObject("algolia", 4)).waitForCompletion();
 
-    assertThat(client.listIndices()).extracting("name").contains("index5");
+    assertThat(client.listIndexes()).extracting("name").contains("index5");
 
     index.copyTo("index6").waitForCompletion();
-    assertThat(client.listIndices()).extracting("name").contains("index5", "index6");
+    assertThat(client.listIndexes()).extracting("name").contains("index5", "index6");
   }
 
   @Test


### PR DESCRIPTION
Closes #422