### PR TITLE
fix(client): Add one deleteIndex method (#427)

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -233,6 +233,37 @@ public class APIClient {
   }
 
   /**
+   * Delete an existing index
+   *
+   * @param indexName The index name that will be deleted
+   * @return The associated task
+   */
+  public Task deleteIndex(@Nonnull String indexName) throws AlgoliaException {
+    return deleteIndex(indexName, RequestOptions.empty);
+  }
+
+  /**
+   * Delete an existing index
+   *
+   * @param indexName The index name that will be deleted
+   * @param requestOptions Options to pass to this request
+   * @return The associated task
+   */
+  public Task deleteIndex(@Nonnull String indexName, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
+    Task result =
+            httpClient.requestWithRetry(
+                    new AlgoliaRequest<>(
+                            HttpMethod.DELETE,
+                            false,
+                            Arrays.asList("1", "indexes", indexName),
+                            requestOptions,
+                            Task.class));
+
+    return result.setAPIClient(this).setIndex(indexName);
+  }
+
+
+  /**
    * Return 10 last log entries.
    *
    * @return A List<Log>
@@ -671,19 +702,6 @@ public class APIClient {
                 MultiQueriesResult.class)
             .setData(new MultipleQueriesRequests(queries))
             .setParameters(ImmutableMap.of("strategy", strategy.getName())));
-  }
-
-  Task deleteIndex(String indexName, RequestOptions requestOptions) throws AlgoliaException {
-    Task result =
-        httpClient.requestWithRetry(
-            new AlgoliaRequest<>(
-                HttpMethod.DELETE,
-                false,
-                Arrays.asList("1", "indexes", indexName),
-                requestOptions,
-                Task.class));
-
-    return result.setAPIClient(this).setIndex(indexName);
   }
 
   <T> TaskIndexing addObject(String indexName, T object, RequestOptions requestOptions)

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -647,8 +647,24 @@ public class AsyncAPIClient {
             .setParameters(ImmutableMap.of("strategy", strategy.getName())));
   }
 
-  /** Package protected method for the Index class */
-  CompletableFuture<AsyncTask> deleteIndex(String indexName, RequestOptions requestOptions) {
+  /**
+   * Delete an existing index
+   *
+   * @param indexName The index name that will be deleted
+   * @return The associated task
+   */
+  public CompletableFuture<AsyncTask> deleteIndex(@Nonnull String indexName) {
+    return deleteIndex(indexName, RequestOptions.empty);
+  }
+
+  /**
+   * Delete an existing index
+   *
+   * @param indexName The index name that will be deleted
+   * @param requestOptions Options to pass to this request
+   * @return The associated task
+   */
+  public CompletableFuture<AsyncTask> deleteIndex(@Nonnull String indexName, @Nonnull RequestOptions requestOptions) {
     return httpClient
         .requestWithRetry(
             new AlgoliaRequest<>(
@@ -660,6 +676,7 @@ public class AsyncAPIClient {
         .thenApply(s -> s.setIndex(indexName));
   }
 
+  /** Package protected method for the Index class */
   <T> CompletableFuture<AsyncTaskIndexing> addObject(
       String indexName, T object, RequestOptions requestOptions) {
     return httpClient


### PR DESCRIPTION
Closes #427 

Apparently, the method with `RequestOptions` wasn't missing. So here, I'm just adding the one without it, to stay consistent with other methods.

# Question
However, I have a question: I've also added the `@Nonnull` annotations on the existing `deleteIndex` method. Will it break existing implementations? It will prevent people passing `null` from compiling but this is really a useful check, it's easy to fix and it shouldn't happen in the first place. WDYT?

# Test plan
As the first method is already tested for both sync and async clients, I have added no tests.