### PR TITLE
Improve javadoc comments

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -114,7 +114,7 @@ public class APIClient {
    * @param srcIndexName the index name that will be the source of the copy
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   public Task moveIndex(@Nonnull String srcIndexName, @Nonnull String dstIndexName)
       throws AlgoliaException {
@@ -128,7 +128,7 @@ public class APIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   public Task moveIndex(
       @Nonnull String srcIndexName,
@@ -154,7 +154,7 @@ public class APIClient {
    * @param srcIndexName the index name that will be the source of the copy
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   public Task copyIndex(@Nonnull String srcIndexName, @Nonnull String dstIndexName)
       throws AlgoliaException {
@@ -168,7 +168,7 @@ public class APIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   public Task copyIndex(
       @Nonnull String srcIndexName,
@@ -186,7 +186,7 @@ public class APIClient {
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   public Task copyIndex(
       @Nonnull String srcIndexName,
@@ -214,7 +214,7 @@ public class APIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
-   * @return The task associated
+   * @return The associated task
    */
   public Task copyIndex(
       @Nonnull String srcIndexName, @Nonnull String dstIndexName, @Nonnull List<String> scopes)

--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -35,8 +35,6 @@ public class APIClient {
 
   /**
    * Close the internal HTTP client
-   *
-   * @throws AlgoliaException
    */
   public void close() throws AlgoliaException {
     this.httpClient.close();
@@ -50,7 +48,6 @@ public class APIClient {
    * List all existing indexes
    *
    * @return A List of the indices and their metadata
-   * @throws AlgoliaException
    */
   public List<Index.Attributes> listIndexes() throws AlgoliaException {
     return listIndexes(RequestOptions.empty);
@@ -61,7 +58,6 @@ public class APIClient {
    *
    * @param requestOptions Options to pass to this request
    * @return A List of the indices and their metadata
-   * @throws AlgoliaException
    */
   public List<Index.Attributes> listIndexes(@Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -119,7 +115,6 @@ public class APIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @return The task associated
-   * @throws AlgoliaException
    */
   public Task moveIndex(@Nonnull String srcIndexName, @Nonnull String dstIndexName)
       throws AlgoliaException {
@@ -134,7 +129,6 @@ public class APIClient {
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
    * @return The task associated
-   * @throws AlgoliaException
    */
   public Task moveIndex(
       @Nonnull String srcIndexName,
@@ -161,7 +155,6 @@ public class APIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @return The task associated
-   * @throws AlgoliaException
    */
   public Task copyIndex(@Nonnull String srcIndexName, @Nonnull String dstIndexName)
       throws AlgoliaException {
@@ -176,7 +169,6 @@ public class APIClient {
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
    * @return The task associated
-   * @throws AlgoliaException
    */
   public Task copyIndex(
       @Nonnull String srcIndexName,
@@ -195,7 +187,6 @@ public class APIClient {
    * @param scopes the list of scopes to copy
    * @param requestOptions Options to pass to this request
    * @return The task associated
-   * @throws AlgoliaException
    */
   public Task copyIndex(
       @Nonnull String srcIndexName,
@@ -224,7 +215,6 @@ public class APIClient {
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
    * @return The task associated
-   * @throws AlgoliaException
    */
   public Task copyIndex(
       @Nonnull String srcIndexName, @Nonnull String dstIndexName, @Nonnull List<String> scopes)
@@ -236,7 +226,6 @@ public class APIClient {
    * Return 10 last log entries.
    *
    * @return A List<Log>
-   * @throws AlgoliaException
    */
   public List<Log> getLogs() throws AlgoliaException {
     return getLogs(RequestOptions.empty);
@@ -247,7 +236,6 @@ public class APIClient {
    *
    * @param requestOptions Options to pass to this request
    * @return A List<Log>
-   * @throws AlgoliaException
    */
   public List<Log> getLogs(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     Logs result =
@@ -266,7 +254,6 @@ public class APIClient {
    *     allowed value: 1000
    * @param logType Specify the type of log to retrieve
    * @return The List of Logs
-   * @throws AlgoliaException
    */
   public List<Log> getLogs(
       @Nonnull Integer offset, @Nonnull Integer length, @Nonnull LogType logType)
@@ -283,7 +270,6 @@ public class APIClient {
    * @param logType Specify the type of log to retrieve
    * @param requestOptions Options to pass to this request
    * @return The List of Logs
-   * @throws AlgoliaException
    */
   public List<Log> getLogs(
       @Nonnull Integer offset,
@@ -317,7 +303,6 @@ public class APIClient {
    * List all existing user keys with their associated ACLs
    *
    * @return A List of Keys
-   * @throws AlgoliaException
    */
   public List<ApiKey> listApiKeys() throws AlgoliaException {
     return this.listApiKeys(RequestOptions.empty);
@@ -328,7 +313,6 @@ public class APIClient {
    *
    * @param requestOptions Options to pass to this request
    * @return A List of Keys
-   * @throws AlgoliaException
    */
   public List<ApiKey> listApiKeys(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     ApiKeys result =
@@ -350,7 +334,6 @@ public class APIClient {
    *
    * @param key name of the key
    * @return the key
-   * @throws AlgoliaException
    */
   public Optional<ApiKey> getApiKey(@Nonnull String key) throws AlgoliaException {
     return this.getApiKey(key, RequestOptions.empty);
@@ -362,7 +345,6 @@ public class APIClient {
    * @param key name of the key
    * @param requestOptions Options to pass to this request
    * @return the key
-   * @throws AlgoliaException
    */
   public Optional<ApiKey> getApiKey(@Nonnull String key, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -386,7 +368,6 @@ public class APIClient {
    * Delete an existing key
    *
    * @param key name of the key
-   * @throws AlgoliaException
    */
   public DeleteKey deleteApiKey(@Nonnull String key) throws AlgoliaException {
     return deleteApiKey(key, RequestOptions.empty);
@@ -397,7 +378,6 @@ public class APIClient {
    *
    * @param key name of the key
    * @param requestOptions Options to pass to this request
-   * @throws AlgoliaException
    */
   public DeleteKey deleteApiKey(@Nonnull String key, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -421,7 +401,6 @@ public class APIClient {
    *
    * @param key the key with the ACLs
    * @return the metadata of the key (such as it's name)
-   * @throws AlgoliaException
    */
   public CreateUpdateKey addApiKey(@Nonnull ApiKey key) throws AlgoliaException {
     return addApiKey(key, RequestOptions.empty);
@@ -433,7 +412,6 @@ public class APIClient {
    * @param key the key with the ACLs
    * @param requestOptions Options to pass to this request
    * @return the metadata of the key (such as it's name)
-   * @throws AlgoliaException
    */
   public CreateUpdateKey addApiKey(@Nonnull ApiKey key, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -460,7 +438,6 @@ public class APIClient {
    * @param keyName name of the key to update
    * @param key the key with the ACLs
    * @return the metadata of the key (such as it's name)
-   * @throws AlgoliaException
    */
   public CreateUpdateKey updateApiKey(@Nonnull String keyName, @Nonnull ApiKey key)
       throws AlgoliaException {
@@ -474,7 +451,6 @@ public class APIClient {
    * @param key the key with the ACLs
    * @param requestOptions Options to pass to this request
    * @return the metadata of the key (such as it's name)
-   * @throws AlgoliaException
    */
   public CreateUpdateKey updateApiKey(
       @Nonnull String keyName, @Nonnull ApiKey key, @Nonnull RequestOptions requestOptions)
@@ -495,7 +471,6 @@ public class APIClient {
    *
    * @param privateApiKey your private API Key
    * @param query contains the parameter applied to the query (used as security)
-   * @throws AlgoliaException
    */
   @SuppressWarnings("unused")
   public String generateSecuredApiKey(@Nonnull String privateApiKey, @Nonnull Query query)
@@ -510,7 +485,6 @@ public class APIClient {
    * @param privateApiKey your private API Key
    * @param query contains the parameter applied to the query (used as security)
    * @param userToken an optional token identifying the current user
-   * @throws AlgoliaException
    */
   @SuppressWarnings("WeakerAccess")
   public String generateSecuredApiKey(
@@ -564,7 +538,6 @@ public class APIClient {
    *
    * @param operations the list of operations to perform
    * @return the associated task
-   * @throws AlgoliaException
    */
   public TasksMultipleIndex batch(@Nonnull List<BatchOperation> operations)
       throws AlgoliaException {
@@ -581,7 +554,6 @@ public class APIClient {
    * @param operations the list of operations to perform
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   public TasksMultipleIndex batch(
       @Nonnull List<BatchOperation> operations, @Nonnull RequestOptions requestOptions)
@@ -611,7 +583,6 @@ public class APIClient {
    *
    * @param queries the queries
    * @return the result of the queries
-   * @throws AlgoliaException
    */
   public MultiQueriesResult multipleQueries(@Nonnull List<IndexQuery> queries)
       throws AlgoliaException {
@@ -625,7 +596,6 @@ public class APIClient {
    * @param queries the queries
    * @param requestOptions Options to pass to this request
    * @return the result of the queries
-   * @throws AlgoliaException
    */
   public MultiQueriesResult multipleQueries(
       @Nonnull List<IndexQuery> queries, @Nonnull RequestOptions requestOptions)
@@ -639,7 +609,6 @@ public class APIClient {
    * @param queries the queries
    * @param strategy the strategy to apply to this multiple queries
    * @return the result of the queries
-   * @throws AlgoliaException
    */
   public MultiQueriesResult multipleQueries(
       @Nonnull List<IndexQuery> queries, @Nonnull MultiQueriesStrategy strategy)
@@ -654,7 +623,6 @@ public class APIClient {
    * @param strategy the strategy to apply to this multiple queries
    * @param requestOptions Options to pass to this request
    * @return the result of the queries
-   * @throws AlgoliaException
    */
   @SuppressWarnings("WeakerAccess")
   public MultiQueriesResult multipleQueries(

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -106,7 +106,7 @@ public class AsyncAPIClient {
    * @param srcIndexName the index name that will be the source of the copy
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   public CompletableFuture<AsyncTask> moveIndex(
       @Nonnull String srcIndexName, @Nonnull String dstIndexName) {
@@ -120,7 +120,7 @@ public class AsyncAPIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   public CompletableFuture<AsyncTask> moveIndex(
       @Nonnull String srcIndexName,
@@ -144,7 +144,7 @@ public class AsyncAPIClient {
    * @param srcIndexName the index name that will be the source of the copy
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   public CompletableFuture<AsyncTask> copyIndex(
       @Nonnull String srcIndexName, @Nonnull String dstIndexName) {
@@ -158,7 +158,7 @@ public class AsyncAPIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   public CompletableFuture<AsyncTask> copyIndex(
       @Nonnull String srcIndexName,
@@ -175,7 +175,7 @@ public class AsyncAPIClient {
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   public CompletableFuture<AsyncTask> copyIndex(
       @Nonnull String srcIndexName,
@@ -201,7 +201,7 @@ public class AsyncAPIClient {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
-   * @return The task associated
+   * @return The associated task
    */
   public CompletableFuture<AsyncTask> copyIndex(
       @Nonnull String srcIndexName, @Nonnull String dstIndexName, @Nonnull List<String> scopes) {

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -40,8 +40,6 @@ public class AsyncAPIClient {
 
   /**
    * Close the internal HTTP client
-   *
-   * @throws AlgoliaException
    */
   public void close() throws AlgoliaException {
     this.httpClient.close();

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndexCRUD.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncIndexCRUD.java
@@ -13,7 +13,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    *
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   default CompletableFuture<AsyncTask> moveTo(@Nonnull String dstIndexName) {
     return moveTo(dstIndexName, RequestOptions.empty);
@@ -25,7 +25,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   default CompletableFuture<AsyncTask> moveTo(
       @Nonnull String dstIndexName, @Nonnull RequestOptions requestOptions) {
@@ -37,7 +37,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    *
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   default CompletableFuture<AsyncTask> copyTo(@Nonnull String dstIndexName) {
     return copyTo(dstIndexName, RequestOptions.empty);
@@ -49,7 +49,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   default CompletableFuture<AsyncTask> copyTo(
       @Nonnull String dstIndexName, @Nonnull RequestOptions requestOptions) {
@@ -63,7 +63,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   default CompletableFuture<AsyncTask> copyTo(
       @Nonnull String dstIndexName,
@@ -78,7 +78,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
-   * @return The task associated
+   * @return The associated task
    */
   default CompletableFuture<AsyncTask> copyTo(
       @Nonnull String dstIndexName, @Nonnull List<String> scopes) {
@@ -88,7 +88,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
   /**
    * Deletes the index
    *
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> delete() {
     return delete(RequestOptions.empty);
@@ -98,7 +98,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    * Deletes the index
    *
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> delete(@Nonnull RequestOptions requestOptions) {
     return getApiClient().deleteIndex(getName(), requestOptions);
@@ -107,7 +107,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
   /**
    * Delete the index content without removing settings and index specific API keys.
    *
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> clear() {
     return clear(RequestOptions.empty);
@@ -117,7 +117,7 @@ public interface AsyncIndexCRUD<T> extends AsyncBaseIndex<T> {
    * Delete the index content without removing settings and index specific API keys.
    *
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> clear(@Nonnull RequestOptions requestOptions) {
     return getApiClient().clearIndex(getName(), requestOptions);

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncObjects.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncObjects.java
@@ -15,7 +15,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * Add an object in this index
    *
    * @param object object to add
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskIndexing> addObject(@Nonnull T object) {
     return addObject(object, RequestOptions.empty);
@@ -26,7 +26,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    *
    * @param object object to add
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskIndexing> addObject(
       @Nonnull T object, @Nonnull RequestOptions requestOptions) {
@@ -39,7 +39,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * @param objectID the objectID associated to this object (if this objectID already exist the old
    *     object will be overridden)
    * @param object object to add
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskIndexing> addObject(
       @Nonnull String objectID, @Nonnull T object) {
@@ -53,7 +53,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    *     object will be overridden)
    * @param object object to add
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskIndexing> addObject(
       @Nonnull String objectID, @Nonnull T object, @Nonnull RequestOptions requestOptions) {
@@ -64,7 +64,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * Add several objects
    *
    * @param objects objects to add
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskSingleIndex> addObjects(@Nonnull List<T> objects) {
     return addObjects(objects, RequestOptions.empty);
@@ -75,7 +75,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    *
    * @param objects objects to add
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskSingleIndex> addObjects(
       @Nonnull List<T> objects, @Nonnull RequestOptions requestOptions) {
@@ -159,7 +159,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    *
    * @param objectID the unique identifier of the object to retrieve
    * @param object the object to update
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> saveObject(@Nonnull String objectID, @Nonnull T object) {
     return saveObject(objectID, object, RequestOptions.empty);
@@ -171,7 +171,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * @param objectID the unique identifier of the object to retrieve
    * @param object the object to update
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> saveObject(
       @Nonnull String objectID, @Nonnull T object, @Nonnull RequestOptions requestOptions) {
@@ -182,7 +182,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * Override the content the list of objects
    *
    * @param objects the list objects to update
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskSingleIndex> saveObjects(@Nonnull List<T> objects) {
     return saveObjects(objects, RequestOptions.empty);
@@ -193,7 +193,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    *
    * @param objects the list objects to update
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskSingleIndex> saveObjects(
       @Nonnull List<T> objects, @Nonnull RequestOptions requestOptions) {
@@ -204,7 +204,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * Delete an object from the index
    *
    * @param objectID the unique identifier of the object to retrieve
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> deleteObject(@Nonnull String objectID) {
     return deleteObject(objectID, RequestOptions.empty);
@@ -215,7 +215,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    *
    * @param objectID the unique identifier of the object to retrieve
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> deleteObject(
       @Nonnull String objectID, @Nonnull RequestOptions requestOptions) {
@@ -226,7 +226,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * Delete objects from the index
    *
    * @param objectIDs the list of unique identifier of the object to retrieve
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskSingleIndex> deleteObjects(@Nonnull List<String> objectIDs) {
     return deleteObjects(objectIDs, RequestOptions.empty);
@@ -237,7 +237,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    *
    * @param objectIDs the list of unique identifier of the object to retrieve
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTaskSingleIndex> deleteObjects(
       @Nonnull List<String> objectIDs, @Nonnull RequestOptions requestOptions) {

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncPartialUpdate.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncPartialUpdate.java
@@ -68,7 +68,6 @@ public interface AsyncPartialUpdate<T> extends AsyncBaseIndex<T> {
    *     exists
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObjects(
       @Nonnull List<Object> objects,
@@ -85,7 +84,6 @@ public interface AsyncPartialUpdate<T> extends AsyncBaseIndex<T> {
    * @param createIfNotExists Value that indicates the object is created if the objectID doesn't
    *     exists
    * @return the associated task
-   * @throws AlgoliaException
    */
   default CompletableFuture<AsyncTaskSingleIndex> partialUpdateObjects(
       @Nonnull List<Object> objects, boolean createIfNotExists) {

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncSettings.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncSettings.java
@@ -31,7 +31,7 @@ public interface AsyncSettings<T> extends AsyncBaseIndex<T> {
    * Set settings of this index, and do not forward to replicas
    *
    * @param settings the settings to set
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> setSettings(@Nonnull IndexSettings settings) {
     return setSettings(settings, false);
@@ -42,7 +42,7 @@ public interface AsyncSettings<T> extends AsyncBaseIndex<T> {
    *
    * @param settings the settings to set
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> setSettings(
       @Nonnull IndexSettings settings, @Nonnull RequestOptions requestOptions) {
@@ -54,7 +54,7 @@ public interface AsyncSettings<T> extends AsyncBaseIndex<T> {
    *
    * @param settings the settings to set
    * @param forwardToReplicas should these updates be forwarded to the replicas
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> setSettings(
       @Nonnull IndexSettings settings, @Nonnull Boolean forwardToReplicas) {
@@ -67,7 +67,7 @@ public interface AsyncSettings<T> extends AsyncBaseIndex<T> {
    * @param settings the settings to set
    * @param forwardToReplicas should these updates be forwarded to the slaves
    * @param requestOptions Options to pass to this request
-   * @return the related AsyncTask
+   * @return the associated AsyncTask
    */
   default CompletableFuture<AsyncTask> setSettings(
       @Nonnull IndexSettings settings,

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncTasks.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncTasks.java
@@ -44,7 +44,6 @@ public interface AsyncTasks<T> extends AsyncBaseIndex<T> {
    * Wait for the completion of a task, for 100ms
    *
    * @param taskID ID of the task to wait for
-   * @throws AlgoliaException
    */
   default void waitTask(@Nonnull Long taskID) throws AlgoliaException {
     AsyncTask task = new AsyncTask().setIndex(getName()).setTaskID(taskID);

--- a/algoliasearch-common/src/main/java/com/algolia/search/Index.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/Index.java
@@ -56,7 +56,6 @@ public class Index<T>
    *
    * @param query the query
    * @return the result of the search
-   * @throws AlgoliaException
    */
   public SearchResult<T> search(@Nonnull Query query) throws AlgoliaException {
     return search(query, RequestOptions.empty);
@@ -68,7 +67,6 @@ public class Index<T>
    *
    * @param query the query
    * @return the result of the search
-   * @throws AlgoliaException
    */
   public SearchResult<T> search(@Nonnull Query query, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -82,7 +80,6 @@ public class Index<T>
    *
    * @param operations the list of operations to perform on this index
    * @return the associated task
-   * @throws AlgoliaException
    * @see BatchOperation & subclasses
    */
   public TaskSingleIndex batch(@Nonnull List<BatchOperation> operations) throws AlgoliaException {
@@ -97,7 +94,6 @@ public class Index<T>
    * @param operations the list of operations to perform on this index
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    * @see BatchOperation & subclasses
    */
   public TaskSingleIndex batch(

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncBrowse.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncBrowse.java
@@ -15,7 +15,6 @@ public interface SyncBrowse<T> extends SyncBaseIndex<T> {
    *
    * @param query The query to use to browse
    * @return the iterator on top of this index
-   * @throws AlgoliaException
    */
   default IndexIterable<T> browse(@Nonnull Query query) {
     return browse(query, RequestOptions.empty);
@@ -27,7 +26,6 @@ public interface SyncBrowse<T> extends SyncBaseIndex<T> {
    * @param query The query to use to browse
    * @param requestOptions Options to pass to this request
    * @return the iterator on top of this index
-   * @throws AlgoliaException
    */
   default IndexIterable<T> browse(@Nonnull Query query, @Nonnull RequestOptions requestOptions) {
     return new IndexIterable<>(getApiClient(), getName(), query, requestOptions, getKlass());
@@ -39,7 +37,6 @@ public interface SyncBrowse<T> extends SyncBaseIndex<T> {
    * @param query The query to use to browse
    * @param cursor the cursor to start from
    * @return browse result
-   * @throws AlgoliaException
    */
   default BrowseResult<T> browseFrom(@Nonnull Query query, @Nullable String cursor)
       throws AlgoliaException {
@@ -53,7 +50,6 @@ public interface SyncBrowse<T> extends SyncBaseIndex<T> {
    * @param cursor the cursor to start from
    * @param requestOptions Options to pass to this request
    * @return the iterator on top of this index
-   * @throws AlgoliaException
    */
   default BrowseResult<T> browseFrom(
       @Nonnull Query query, @Nullable String cursor, @Nonnull RequestOptions requestOptions)

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncDeleteByQuery.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncDeleteByQuery.java
@@ -19,7 +19,6 @@ public interface SyncDeleteByQuery<T> extends SyncBaseIndex<T> {
    * Delete records matching a query
    *
    * @param query The query
-   * @throws AlgoliaException
    */
   default Task deleteBy(@Nonnull Query query) throws AlgoliaException {
     return deleteBy(query, RequestOptions.empty);
@@ -37,7 +36,6 @@ public interface SyncDeleteByQuery<T> extends SyncBaseIndex<T> {
    *
    * @param query The query
    * @param requestOptions Options to pass to this request
-   * @throws AlgoliaException
    */
   default Task deleteBy(@Nonnull Query query, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncIndexCRUD.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncIndexCRUD.java
@@ -12,7 +12,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
   /**
    * Deletes the index
    *
-   * @return the related Task
+   * @return the associated Task
    */
   default Task delete() throws AlgoliaException {
     return delete(RequestOptions.empty);
@@ -22,7 +22,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * Deletes the index
    *
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default Task delete(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return getApiClient().deleteIndex(getName(), requestOptions);
@@ -31,7 +31,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
   /**
    * Delete the index content without removing settings and index specific API keys.
    *
-   * @return the related Task
+   * @return the associated Task
    */
   default Task clear() throws AlgoliaException {
     return clear(RequestOptions.empty);
@@ -41,7 +41,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * Delete the index content without removing settings and index specific API keys.
    *
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default Task clear(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return getApiClient().clearIndex(getName(), requestOptions);
@@ -52,7 +52,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   default Task moveTo(@Nonnull String dstIndexName) throws AlgoliaException {
     return moveTo(dstIndexName, RequestOptions.empty);
@@ -64,7 +64,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   default Task moveTo(@Nonnull String dstIndexName, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -76,7 +76,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
-   * @return The task associated
+   * @return The associated task
    */
   default Task copyTo(@Nonnull String dstIndexName) throws AlgoliaException {
     return copyTo(dstIndexName, RequestOptions.empty);
@@ -88,7 +88,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   default Task copyTo(@Nonnull String dstIndexName, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -102,7 +102,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
    * @param requestOptions Options to pass to this request
-   * @return The task associated
+   * @return The associated task
    */
   default Task copyTo(
       @Nonnull String dstIndexName,
@@ -118,7 +118,7 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
-   * @return The task associated
+   * @return The associated task
    */
   default Task copyTo(@Nonnull String dstIndexName, @Nonnull List<String> scopes)
       throws AlgoliaException {

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncIndexCRUD.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncIndexCRUD.java
@@ -13,7 +13,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * Deletes the index
    *
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task delete() throws AlgoliaException {
     return delete(RequestOptions.empty);
@@ -24,7 +23,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task delete(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return getApiClient().deleteIndex(getName(), requestOptions);
@@ -34,7 +32,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * Delete the index content without removing settings and index specific API keys.
    *
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task clear() throws AlgoliaException {
     return clear(RequestOptions.empty);
@@ -45,7 +42,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task clear(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return getApiClient().clearIndex(getName(), requestOptions);
@@ -57,7 +53,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @return The task associated
-   * @throws AlgoliaException
    */
   default Task moveTo(@Nonnull String dstIndexName) throws AlgoliaException {
     return moveTo(dstIndexName, RequestOptions.empty);
@@ -70,7 +65,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
    * @return The task associated
-   * @throws AlgoliaException
    */
   default Task moveTo(@Nonnull String dstIndexName, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -83,7 +77,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination
    *     will be overwritten if it already exist)
    * @return The task associated
-   * @throws AlgoliaException
    */
   default Task copyTo(@Nonnull String dstIndexName) throws AlgoliaException {
     return copyTo(dstIndexName, RequestOptions.empty);
@@ -96,7 +89,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *     will be overwritten if it already exist)
    * @param requestOptions Options to pass to this request
    * @return The task associated
-   * @throws AlgoliaException
    */
   default Task copyTo(@Nonnull String dstIndexName, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -111,7 +103,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    * @param scopes the list of scopes to copy
    * @param requestOptions Options to pass to this request
    * @return The task associated
-   * @throws AlgoliaException
    */
   default Task copyTo(
       @Nonnull String dstIndexName,
@@ -128,7 +119,6 @@ public interface SyncIndexCRUD<T> extends SyncBaseIndex<T> {
    *     will be overwritten if it already exist)
    * @param scopes the list of scopes to copy
    * @return The task associated
-   * @throws AlgoliaException
    */
   default Task copyTo(@Nonnull String dstIndexName, @Nonnull List<String> scopes)
       throws AlgoliaException {

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncKey.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncKey.java
@@ -22,7 +22,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    * List keys of this index
    *
    * @return the list of keys
-   * @throws AlgoliaException
    */
   default List<ApiKey> listApiKeys() throws AlgoliaException {
     return listApiKeys(RequestOptions.empty);
@@ -33,7 +32,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    *
    * @param requestOptions Options to pass to this request
    * @return the list of keys
-   * @throws AlgoliaException
    */
   default List<ApiKey> listApiKeys(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return getApiClient().listKeys(getName(), requestOptions);
@@ -50,7 +48,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    *
    * @param key the key name
    * @return the key
-   * @throws AlgoliaException
    */
   default Optional<ApiKey> getApiKey(@Nonnull String key) throws AlgoliaException {
     return getApiKey(key, RequestOptions.empty);
@@ -62,7 +59,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    * @param key the key name
    * @param requestOptions Options to pass to this request
    * @return the key
-   * @throws AlgoliaException
    */
   default Optional<ApiKey> getApiKey(@Nonnull String key, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -80,7 +76,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    *
    * @param key the key name
    * @return the deleted key
-   * @throws AlgoliaException
    */
   default DeleteKey deleteApiKey(@Nonnull String key) throws AlgoliaException {
     return deleteApiKey(key, RequestOptions.empty);
@@ -92,7 +87,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    * @param key the key name
    * @param requestOptions Options to pass to this request
    * @return the deleted key
-   * @throws AlgoliaException
    */
   default DeleteKey deleteApiKey(@Nonnull String key, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -110,7 +104,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    *
    * @param key the key
    * @return the created key
-   * @throws AlgoliaException
    */
   default CreateUpdateKey addApiKey(@Nonnull ApiKey key) throws AlgoliaException {
     return addApiKey(key, RequestOptions.empty);
@@ -122,7 +115,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    * @param key the key
    * @param requestOptions Options to pass to this request
    * @return the created key
-   * @throws AlgoliaException
    */
   default CreateUpdateKey addApiKey(@Nonnull ApiKey key, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -142,7 +134,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    * @param keyName the key name
    * @param key the key to update
    * @return the updated key
-   * @throws AlgoliaException
    */
   default CreateUpdateKey updateApiKey(@Nonnull String keyName, @Nonnull ApiKey key)
       throws AlgoliaException {
@@ -164,7 +155,6 @@ public interface SyncKey<T> extends SyncBaseIndex<T> {
    * @param key the key to update
    * @param requestOptions Options to pass to this request
    * @return the updated key
-   * @throws AlgoliaException
    */
   default CreateUpdateKey updateApiKey(
       @Nonnull String keyName, @Nonnull ApiKey key, @Nonnull RequestOptions requestOptions)

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncObjects.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncObjects.java
@@ -17,7 +17,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param object object to add
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskIndexing addObject(@Nonnull T object) throws AlgoliaException {
     return addObject(object, RequestOptions.empty);
@@ -29,7 +28,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param object object to add
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskIndexing addObject(@Nonnull T object, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -43,7 +41,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *     object will be overridden)
    * @param object object to add
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskIndexing addObject(@Nonnull String objectID, @Nonnull T object)
       throws AlgoliaException {
@@ -58,7 +55,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param object object to add
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskIndexing addObject(
       @Nonnull String objectID, @Nonnull T object, @Nonnull RequestOptions requestOptions)
@@ -71,7 +67,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objects objects to add
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex addObjects(@Nonnull List<T> objects) throws AlgoliaException {
     return addObjects(objects, RequestOptions.empty);
@@ -83,7 +78,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objects objects to add
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex addObjects(
       @Nonnull List<T> objects, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
@@ -95,7 +89,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objectID the unique identifier of the object to retrieve
    * @return The object
-   * @throws AlgoliaException
    */
   default Optional<T> getObject(@Nonnull String objectID) throws AlgoliaException {
     return getObject(objectID, RequestOptions.empty);
@@ -107,7 +100,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectID the unique identifier of the object to retrieve
    * @param requestOptions Options to pass to this request
    * @return The object
-   * @throws AlgoliaException
    */
   default Optional<T> getObject(@Nonnull String objectID, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -119,7 +111,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objectIDs the list of unique identifier of objects to retrieve
    * @return the list of objects
-   * @throws AlgoliaException
    */
   default List<T> getObjects(@Nonnull List<String> objectIDs) throws AlgoliaException {
     return getObjects(objectIDs, RequestOptions.empty);
@@ -131,7 +122,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectIDs the list of unique identifier of objects to retrieve
    * @param requestOptions Options to pass to this request
    * @return the list of objects
-   * @throws AlgoliaException
    */
   default List<T> getObjects(
       @Nonnull List<String> objectIDs, @Nonnull RequestOptions requestOptions)
@@ -145,7 +135,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectIDs the list of unique identifier of objects to retrieve
    * @param attributesToRetrieve the list of attributes to retrieve for these objects
    * @return the list of objects
-   * @throws AlgoliaException
    */
   default List<T> getObjects(
       @Nonnull List<String> objectIDs, @Nonnull List<String> attributesToRetrieve)
@@ -160,7 +149,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param attributesToRetrieve the list of attributes to retrieve for these objects
    * @param requestOptions Options to pass to this request
    * @return the list of objects
-   * @throws AlgoliaException
    */
   default List<T> getObjects(
       @Nonnull List<String> objectIDs,
@@ -177,7 +165,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectID the unique identifier of the object to retrieve
    * @param object the object to update
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task saveObject(@Nonnull String objectID, @Nonnull T object) throws AlgoliaException {
     return saveObject(objectID, object, RequestOptions.empty);
@@ -190,7 +177,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param object the object to update
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task saveObject(
       @Nonnull String objectID, @Nonnull T object, @Nonnull RequestOptions requestOptions)
@@ -203,7 +189,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objects the list objects to update
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex saveObjects(@Nonnull List<T> objects) throws AlgoliaException {
     return saveObjects(objects, RequestOptions.empty);
@@ -215,7 +200,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objects the list objects to update
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex saveObjects(
       @Nonnull List<T> objects, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
@@ -227,7 +211,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objectID the unique identifier of the object to retrieve
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task deleteObject(@Nonnull String objectID) throws AlgoliaException {
     return deleteObject(objectID, RequestOptions.empty);
@@ -239,7 +222,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectID the unique identifier of the object to retrieve
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task deleteObject(@Nonnull String objectID, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -251,7 +233,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objectIDs the list of unique identifier of the object to retrieve
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex deleteObjects(@Nonnull List<String> objectIDs) throws AlgoliaException {
     return deleteObjects(objectIDs, RequestOptions.empty);
@@ -263,7 +244,6 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectIDs the list of unique identifier of the object to retrieve
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex deleteObjects(
       @Nonnull List<String> objectIDs, @Nonnull RequestOptions requestOptions)

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncObjects.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncObjects.java
@@ -16,7 +16,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * Add an object in this index
    *
    * @param object object to add
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskIndexing addObject(@Nonnull T object) throws AlgoliaException {
     return addObject(object, RequestOptions.empty);
@@ -27,7 +27,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param object object to add
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskIndexing addObject(@Nonnull T object, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -40,7 +40,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectID the objectID associated to this object (if this objectID already exist the old
    *     object will be overridden)
    * @param object object to add
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskIndexing addObject(@Nonnull String objectID, @Nonnull T object)
       throws AlgoliaException {
@@ -54,7 +54,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *     object will be overridden)
    * @param object object to add
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskIndexing addObject(
       @Nonnull String objectID, @Nonnull T object, @Nonnull RequestOptions requestOptions)
@@ -66,7 +66,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * Add several objects
    *
    * @param objects objects to add
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskSingleIndex addObjects(@Nonnull List<T> objects) throws AlgoliaException {
     return addObjects(objects, RequestOptions.empty);
@@ -77,7 +77,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objects objects to add
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskSingleIndex addObjects(
       @Nonnull List<T> objects, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
@@ -164,7 +164,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objectID the unique identifier of the object to retrieve
    * @param object the object to update
-   * @return the related Task
+   * @return the associated Task
    */
   default Task saveObject(@Nonnull String objectID, @Nonnull T object) throws AlgoliaException {
     return saveObject(objectID, object, RequestOptions.empty);
@@ -176,7 +176,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * @param objectID the unique identifier of the object to retrieve
    * @param object the object to update
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default Task saveObject(
       @Nonnull String objectID, @Nonnull T object, @Nonnull RequestOptions requestOptions)
@@ -188,7 +188,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * Override the content the list of objects
    *
    * @param objects the list objects to update
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskSingleIndex saveObjects(@Nonnull List<T> objects) throws AlgoliaException {
     return saveObjects(objects, RequestOptions.empty);
@@ -199,7 +199,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objects the list objects to update
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskSingleIndex saveObjects(
       @Nonnull List<T> objects, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
@@ -210,7 +210,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * Delete an object from the index
    *
    * @param objectID the unique identifier of the object to retrieve
-   * @return the related Task
+   * @return the associated Task
    */
   default Task deleteObject(@Nonnull String objectID) throws AlgoliaException {
     return deleteObject(objectID, RequestOptions.empty);
@@ -221,7 +221,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objectID the unique identifier of the object to retrieve
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default Task deleteObject(@Nonnull String objectID, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -232,7 +232,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    * Delete objects from the index
    *
    * @param objectIDs the list of unique identifier of the object to retrieve
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskSingleIndex deleteObjects(@Nonnull List<String> objectIDs) throws AlgoliaException {
     return deleteObjects(objectIDs, RequestOptions.empty);
@@ -243,7 +243,7 @@ public interface SyncObjects<T> extends SyncBaseIndex<T> {
    *
    * @param objectIDs the list of unique identifier of the object to retrieve
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default TaskSingleIndex deleteObjects(
       @Nonnull List<String> objectIDs, @Nonnull RequestOptions requestOptions)

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncPartialUpdate.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncPartialUpdate.java
@@ -15,7 +15,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param objectID the ID of object to update
    * @param object the object to update
    * @return the associated task
-   * @throws AlgoliaException
    * @see PartialUpdateOperation & subclasses
    */
   default TaskSingleIndex partialUpdateObject(@Nonnull String objectID, @Nonnull Object object)
@@ -30,7 +29,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param object the object to update
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    * @see PartialUpdateOperation & subclasses
    */
   default TaskSingleIndex partialUpdateObject(
@@ -44,7 +42,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    *
    * @param objects the list of objects to update (with an objectID)
    * @return the associated task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex partialUpdateObjects(@Nonnull List<Object> objects)
       throws AlgoliaException {
@@ -57,7 +54,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param objects the list of objects to update (with an objectID)
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex partialUpdateObjects(
       @Nonnull List<Object> objects, @Nonnull RequestOptions requestOptions)
@@ -73,7 +69,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param createIfNotExists Value that indicates the object is created if the objectID doesn't
    *     exists
    * @return the associated task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex partialUpdateObjects(
       @Nonnull List<Object> objects,
@@ -91,7 +86,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param createIfNotExists Value that indicates the object is created if the objectID doesn't
    *     exists
    * @return the associated task
-   * @throws AlgoliaException
    */
   default TaskSingleIndex partialUpdateObjects(
       @Nonnull List<Object> objects, boolean createIfNotExists) throws AlgoliaException {
@@ -103,7 +97,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    *
    * @param operation the operation to perform on this object
    * @return the associated task
-   * @throws AlgoliaException
    * @see PartialUpdateOperation & subclasses
    */
   default TaskSingleIndex partialUpdateObject(@Nonnull PartialUpdateOperation operation)
@@ -117,7 +110,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param operation the operation to perform on this object
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    * @see PartialUpdateOperation & subclasses
    */
   default TaskSingleIndex partialUpdateObject(
@@ -132,7 +124,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param operation the operation to perform on this object
    * @param createIfNotExists should the object be created or not
    * @return the associated task
-   * @throws AlgoliaException
    * @see PartialUpdateOperation & subclasses
    */
   default TaskSingleIndex partialUpdateObject(
@@ -148,7 +139,6 @@ public interface SyncPartialUpdate<T> extends SyncBaseIndex<T> {
    * @param createIfNotExists should the object be created or not
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    * @see PartialUpdateOperation & subclasses
    */
   default TaskSingleIndex partialUpdateObject(

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncRules.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncRules.java
@@ -18,7 +18,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param queryRuleID the id of the queryRule
    * @param content the queryRule
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveRule(@Nonnull String queryRuleID, @Nonnull Rule content)
       throws AlgoliaException {
@@ -32,7 +31,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param content the queryRule
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveRule(
       @Nonnull String queryRuleID, @Nonnull Rule content, @Nonnull RequestOptions requestOptions)
@@ -47,7 +45,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param content the queryRule
    * @param forwardToReplicas should this request be forwarded to replicas
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveRule(
       @Nonnull String queryRuleID, @Nonnull Rule content, boolean forwardToReplicas)
@@ -63,7 +60,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas should this request be forwarded to replicas
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveRule(
       @Nonnull String queryRuleID,
@@ -80,7 +76,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    *
    * @param ruleId the id of the query rule
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Optional<Rule> getRule(@Nonnull String ruleId) throws AlgoliaException {
     return getRule(ruleId, RequestOptions.empty);
@@ -92,7 +87,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param ruleId the id of the query rule
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Optional<Rule> getRule(@Nonnull String ruleId, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -104,7 +98,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    *
    * @param ruleId the id of the queryRule
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task deleteRule(@Nonnull String ruleId) throws AlgoliaException {
     return deleteRule(ruleId, false, RequestOptions.empty);
@@ -116,7 +109,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param ruleId the id of the queryRule
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task deleteRule(@Nonnull String ruleId, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -130,7 +122,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas should this request be forwarded to replicas
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task deleteRule(
       @Nonnull String ruleId, boolean forwardToReplicas, @Nonnull RequestOptions requestOptions)
@@ -142,7 +133,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * Clear all query Rules and NOT forwarding it to the replicas
    *
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearRules() throws AlgoliaException {
     return clearRules(false);
@@ -153,7 +143,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    *
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearRules(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return clearRules(false, requestOptions);
@@ -163,7 +152,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * Clears all Rules
    *
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearRules(boolean forwardToReplicas) throws AlgoliaException {
     return clearRules(forwardToReplicas, RequestOptions.empty);
@@ -175,7 +163,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas should this request be forwarded to replicas
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearRules(boolean forwardToReplicas, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -187,7 +174,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    *
    * @param query the query
    * @return the results of the query
-   * @throws AlgoliaException
    */
   default SearchRuleResult searchRules(@Nonnull RuleQuery query) throws AlgoliaException {
     return searchRules(query, RequestOptions.empty);
@@ -199,7 +185,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param query the query
    * @param requestOptions Options to pass to this request
    * @return the results of the query
-   * @throws AlgoliaException
    */
   default SearchRuleResult searchRules(
       @Nonnull RuleQuery query, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
@@ -213,7 +198,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas Forward the operation to the slave indices
    * @param clearExistingRules Replace the existing query Rules with this batch
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchRules(
       @Nonnull List<Rule> rules, boolean forwardToReplicas, boolean clearExistingRules)
@@ -229,7 +213,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param clearExistingRules Replace the existing query Rules with this batch
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchRules(
       @Nonnull List<Rule> rules,
@@ -247,7 +230,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param rules List of Rules
    * @param forwardToReplicas Forward the operation to the slave indices
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchRules(@Nonnull List<Rule> rules, boolean forwardToReplicas)
       throws AlgoliaException {
@@ -261,7 +243,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas Forward the operation to the slave indices
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchRules(
       @Nonnull List<Rule> rules, boolean forwardToReplicas, @Nonnull RequestOptions requestOptions)
@@ -274,7 +255,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    *
    * @param rules List of Rules
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchRules(@Nonnull List<Rule> rules) throws AlgoliaException {
     return batchRules(rules, false, false);
@@ -286,7 +266,6 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    * @param rules List of Rules
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchRules(@Nonnull List<Rule> rules, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncSearchForFacet.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncSearchForFacet.java
@@ -16,7 +16,6 @@ public interface SyncSearchForFacet<T> extends SyncBaseIndex<T> {
    * @param facetQuery The search query for this facet
    * @param query the query (not required)
    * @return the result of the search
-   * @throws AlgoliaException
    */
   default SearchFacetResult searchForFacetValues(
       @Nonnull String facetName, @Nonnull String facetQuery, Query query) throws AlgoliaException {
@@ -32,7 +31,6 @@ public interface SyncSearchForFacet<T> extends SyncBaseIndex<T> {
    * @param query the query (not required)
    * @param requestOptions Options to pass to this request
    * @return the result of the search
-   * @throws AlgoliaException
    */
   default SearchFacetResult searchForFacetValues(
       @Nonnull String facetName,
@@ -51,7 +49,6 @@ public interface SyncSearchForFacet<T> extends SyncBaseIndex<T> {
    * @param facetName The name of the facet to search in
    * @param facetQuery The search query for this facet
    * @return the result of the search
-   * @throws AlgoliaException
    */
   default SearchFacetResult searchForFacetValues(
       @Nonnull String facetName, @Nonnull String facetQuery) throws AlgoliaException {
@@ -66,7 +63,6 @@ public interface SyncSearchForFacet<T> extends SyncBaseIndex<T> {
    * @param facetQuery The search query for this facet
    * @param requestOptions Options to pass to this request
    * @return the result of the search
-   * @throws AlgoliaException
    */
   default SearchFacetResult searchForFacetValues(
       @Nonnull String facetName, @Nonnull String facetQuery, @Nonnull RequestOptions requestOptions)

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncSettings.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncSettings.java
@@ -32,7 +32,7 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    * Set settings of this index, and do not forward to replicas
    *
    * @param settings the settings to set
-   * @return the related Task
+   * @return the associated Task
    */
   default Task setSettings(@Nonnull IndexSettings settings) throws AlgoliaException {
     return setSettings(settings, RequestOptions.empty);
@@ -43,7 +43,7 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    *
    * @param settings the settings to set
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default Task setSettings(@Nonnull IndexSettings settings, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -55,7 +55,7 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    *
    * @param settings the settings to set
    * @param forwardToReplicas should these updates be forwarded to the replicas
-   * @return the related Task
+   * @return the associated Task
    */
   default Task setSettings(@Nonnull IndexSettings settings, @Nonnull Boolean forwardToReplicas)
       throws AlgoliaException {
@@ -68,7 +68,7 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    * @param settings the settings to set
    * @param forwardToReplicas should these updates be forwarded to the slaves
    * @param requestOptions Options to pass to this request
-   * @return the related Task
+   * @return the associated Task
    */
   default Task setSettings(
       @Nonnull IndexSettings settings,

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncSettings.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncSettings.java
@@ -12,7 +12,6 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    * Get settings of this index
    *
    * @return the settings
-   * @throws AlgoliaException
    */
   default IndexSettings getSettings() throws AlgoliaException {
     return getSettings(RequestOptions.empty);
@@ -23,7 +22,6 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    *
    * @param requestOptions Options to pass to this request
    * @return the settings
-   * @throws AlgoliaException
    */
   default IndexSettings getSettings(@Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -35,7 +33,6 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    *
    * @param settings the settings to set
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task setSettings(@Nonnull IndexSettings settings) throws AlgoliaException {
     return setSettings(settings, RequestOptions.empty);
@@ -47,7 +44,6 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    * @param settings the settings to set
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task setSettings(@Nonnull IndexSettings settings, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -60,7 +56,6 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    * @param settings the settings to set
    * @param forwardToReplicas should these updates be forwarded to the replicas
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task setSettings(@Nonnull IndexSettings settings, @Nonnull Boolean forwardToReplicas)
       throws AlgoliaException {
@@ -74,7 +69,6 @@ public interface SyncSettings<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas should these updates be forwarded to the slaves
    * @param requestOptions Options to pass to this request
    * @return the related Task
-   * @throws AlgoliaException
    */
   default Task setSettings(
       @Nonnull IndexSettings settings,

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncSynonyms.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncSynonyms.java
@@ -19,7 +19,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param synonymID the id of the synonym
    * @param content the synonym
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveSynonym(@Nonnull String synonymID, @Nonnull AbstractSynonym content)
       throws AlgoliaException {
@@ -33,7 +32,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param content the synonym
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveSynonym(
       @Nonnull String synonymID,
@@ -50,7 +48,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param content the synonym
    * @param forwardToReplicas should this request be forwarded to replicas
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveSynonym(
       @Nonnull String synonymID, @Nonnull AbstractSynonym content, boolean forwardToReplicas)
@@ -66,7 +63,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas should this request be forwarded to slaves
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task saveSynonym(
       @Nonnull String synonymID,
@@ -83,7 +79,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    *
    * @param synonymID the id of the synonym
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Optional<AbstractSynonym> getSynonym(@Nonnull String synonymID) throws AlgoliaException {
     return getSynonym(synonymID, RequestOptions.empty);
@@ -95,7 +90,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param synonymID the id of the synonym
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Optional<AbstractSynonym> getSynonym(
       @Nonnull String synonymID, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
@@ -107,7 +101,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    *
    * @param synonymID the id of the synonym
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task deleteSynonym(@Nonnull String synonymID) throws AlgoliaException {
     return deleteSynonym(synonymID, false);
@@ -119,7 +112,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param synonymID the id of the synonym
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task deleteSynonym(@Nonnull String synonymID, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -132,7 +124,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param synonymID the id of the synonym
    * @param forwardToReplicas should this request be forwarded to replicas
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task deleteSynonym(@Nonnull String synonymID, boolean forwardToReplicas)
       throws AlgoliaException {
@@ -146,7 +137,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas should this request be forwarded to replicas
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task deleteSynonym(
       @Nonnull String synonymID, boolean forwardToReplicas, @Nonnull RequestOptions requestOptions)
@@ -158,7 +148,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * Clear all synonyms and NOT forwarding it to the replicas
    *
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearSynonyms() throws AlgoliaException {
     return clearSynonyms(false);
@@ -169,7 +158,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    *
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearSynonyms(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return clearSynonyms(false, requestOptions);
@@ -180,7 +168,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    *
    * @param forwardToReplicas should this request be forwarded to replicas
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearSynonyms(boolean forwardToReplicas) throws AlgoliaException {
     return clearSynonyms(forwardToReplicas, RequestOptions.empty);
@@ -192,7 +179,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas should this request be forwarded to replicas
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task clearSynonyms(boolean forwardToReplicas, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -204,7 +190,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    *
    * @param query the query
    * @return the results of the query
-   * @throws AlgoliaException
    */
   default SearchSynonymResult searchSynonyms(@Nonnull SynonymQuery query) throws AlgoliaException {
     return searchSynonyms(query, RequestOptions.empty);
@@ -216,7 +201,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param query the query
    * @param requestOptions Options to pass to this request
    * @return the results of the query
-   * @throws AlgoliaException
    */
   default SearchSynonymResult searchSynonyms(
       @Nonnull SynonymQuery query, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
@@ -230,7 +214,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas Forward the operation to the slave indices
    * @param replaceExistingSynonyms Replace the existing synonyms with this batch
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchSynonyms(
       @Nonnull List<AbstractSynonym> synonyms,
@@ -249,7 +232,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param replaceExistingSynonyms Replace the existing synonyms with this batch
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchSynonyms(
       @Nonnull List<AbstractSynonym> synonyms,
@@ -268,7 +250,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param synonyms List of synonyms
    * @param forwardToReplicas Forward the operation to the slave indices
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms, boolean forwardToReplicas)
       throws AlgoliaException {
@@ -282,7 +263,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param forwardToReplicas Forward the operation to the slave indices
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchSynonyms(
       @Nonnull List<AbstractSynonym> synonyms,
@@ -297,7 +277,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    *
    * @param synonyms List of synonyms
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchSynonyms(@Nonnull List<AbstractSynonym> synonyms) throws AlgoliaException {
     return batchSynonyms(synonyms, false, false);
@@ -309,7 +288,6 @@ public interface SyncSynonyms<T> extends SyncBaseIndex<T> {
    * @param synonyms List of synonyms
    * @param requestOptions Options to pass to this request
    * @return the associated task
-   * @throws AlgoliaException
    */
   default Task batchSynonyms(
       @Nonnull List<AbstractSynonym> synonyms, @Nonnull RequestOptions requestOptions)

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncTasks.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncTasks.java
@@ -13,7 +13,6 @@ public interface SyncTasks<T> extends SyncBaseIndex<T> {
    *
    * @param task task to wait for
    * @param timeToWait the time to wait in milliseconds
-   * @throws AlgoliaException
    */
   default void waitTask(@Nonnull Task task, long timeToWait) throws AlgoliaException {
     waitTask(task, timeToWait, RequestOptions.empty);
@@ -25,7 +24,6 @@ public interface SyncTasks<T> extends SyncBaseIndex<T> {
    * @param task task to wait for
    * @param timeToWait the time to wait in milliseconds
    * @param requestOptions Options to pass to this request
-   * @throws AlgoliaException
    */
   default void waitTask(@Nonnull Task task, long timeToWait, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -38,7 +36,6 @@ public interface SyncTasks<T> extends SyncBaseIndex<T> {
    * Wait for the completion of a task, for 100ms
    *
    * @param task task to wait for
-   * @throws AlgoliaException
    */
   default void waitTask(@Nonnull Task task) throws AlgoliaException {
     getApiClient().waitTask(task, 100);
@@ -48,7 +45,6 @@ public interface SyncTasks<T> extends SyncBaseIndex<T> {
    * Wait for the completion of a task, for 100ms
    *
    * @param taskID ID of the task to wait for
-   * @throws AlgoliaException
    */
   default void waitTask(@Nonnull Long taskID) throws AlgoliaException {
     Task task = new Task().setAPIClient(getApiClient()).setIndex(getName()).setTaskID(taskID);
@@ -60,7 +56,6 @@ public interface SyncTasks<T> extends SyncBaseIndex<T> {
    *
    * @param taskID ID of the task to wait for
    * @param requestOptions Options to pass to this request
-   * @throws AlgoliaException
    */
   default void waitTask(@Nonnull Long taskID, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
@@ -73,7 +68,6 @@ public interface SyncTasks<T> extends SyncBaseIndex<T> {
    *
    * @param task task to wait for
    * @param requestOptions Options to pass to this request
-   * @throws AlgoliaException
    */
   default void waitTask(@Nonnull Task task, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/tasks/sync/GenericTask.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/tasks/sync/GenericTask.java
@@ -27,8 +27,6 @@ public abstract class GenericTask<T> extends AbstractTask<T> {
 
   /**
    * Wait for the completion of this task
-   *
-   * @throws AlgoliaException
    */
   public void waitForCompletion() throws AlgoliaException {
     apiClient.waitTask(this, 100);
@@ -38,7 +36,6 @@ public abstract class GenericTask<T> extends AbstractTask<T> {
    * Wait for the completion of this task
    *
    * @param timeToWait the time to wait in milliseconds
-   * @throws AlgoliaException
    */
   public void waitForCompletion(long timeToWait) throws AlgoliaException {
     apiClient.waitTask(this, timeToWait);

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/tasks/sync/Task.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/tasks/sync/Task.java
@@ -21,8 +21,6 @@ public class Task extends GenericTask<Long> {
 
   /**
    * Wait for the completion of this task
-   *
-   * @throws AlgoliaException
    */
   public void waitForCompletion() throws AlgoliaException {
     waitForCompletion(RequestOptions.empty);
@@ -32,7 +30,6 @@ public class Task extends GenericTask<Long> {
    * Wait for the completion of this task
    *
    * @param timeToWait the time to wait in milliseconds
-   * @throws AlgoliaException
    */
   public void waitForCompletion(long timeToWait) throws AlgoliaException {
     waitForCompletion(timeToWait, RequestOptions.empty);
@@ -42,7 +39,6 @@ public class Task extends GenericTask<Long> {
    * Wait for the completion of this task
    *
    * @param requestOptions Options to pass to this request
-   * @throws AlgoliaException
    */
   public void waitForCompletion(@Nonnull RequestOptions requestOptions) throws AlgoliaException {
     waitForCompletion(100, requestOptions);
@@ -53,7 +49,6 @@ public class Task extends GenericTask<Long> {
    *
    * @param timeToWait the time to wait in milliseconds
    * @param requestOptions Options to pass to this request
-   * @throws AlgoliaException
    */
   public void waitForCompletion(long timeToWait, @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {


### PR DESCRIPTION
 - Remove `@throws AlgoliaException` lines
 - Make sure to use the same comment for returned tasks:
    + `s/related/associated` everywhere
    + reverse `task associated` into `associated task` where needed