### PR TITLE
Adds the 'facet_stats' attribute to the SearchResult object

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/responses/SearchResult.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/responses/SearchResult.java
@@ -20,6 +20,8 @@ public class SearchResult<T> implements Serializable {
 
   private Map<String, Map<String, Long>> facets;
 
+  private Map<String, Map<String, Long>> facets_stats;
+
   private Boolean exhaustiveFacetsCount;
 
   private String query;
@@ -117,6 +119,15 @@ public class SearchResult<T> implements Serializable {
 
   public SearchResult setFacets(Map<String, Map<String, Long>> facets) {
     this.facets = facets;
+    return this;
+  }
+
+  public Map<String, Map<String, Long>> getFacets_stats() {
+    return facets_stats;
+  }
+
+  public SearchResult setFacets_stats(Map<String, Map<String, Long>> facets_stats) {
+    this.facets_stats = facets_stats;
     return this;
   }
 


### PR DESCRIPTION
Hi,

The search results from the api contain a map with facet stats per (numerical) facet, but I can't access them. I would like to access them. 

This PR adds the attribute to the SearchResult object. I thought it was best to keep it a map with string keys since I don't want it to break with api updates (new stats keys). 

I ran the tests locally and got `APPLICATION_ID is not defined or empty` errors. I am assuming that is for an integration test I don't have? 

If you have any requests, please let me know. 