### PR TITLE
FIX: Facet stats broken in current release

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/responses/SearchResult.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/responses/SearchResult.java
@@ -20,7 +20,7 @@ public class SearchResult<T> implements Serializable {
 
   private Map<String, Map<String, Long>> facets;
 
-  private Map<String, Float> facets_stats;
+  private Map<String, Map<String, Float>> facets_stats;
 
   private Boolean exhaustiveFacetsCount;
 
@@ -167,11 +167,11 @@ public class SearchResult<T> implements Serializable {
     return this;
   }
 
-  public Map<String, Float> getFacets_stats() {
+  public Map<String, Map<String, Float>> getFacets_stats() {
     return facets_stats;
   }
 
-  public SearchResult<T> setFacets_stats(Map<String, Float> facets_stats) {
+  public SearchResult<T> setFacets_stats(Map<String, Map<String, Float>> facets_stats) {
     this.facets_stats = facets_stats;
     return this;
   }


### PR DESCRIPTION
So it turns out the model is broken in the current release: 

```
com.algolia.search.exceptions.AlgoliaException: Error while deserialization the response
        at com.algolia.search.http.AlgoliaHttpClient.requestWithRetry(AlgoliaHttpClient.java:173)
        at com.algolia.search.APIClient.search(APIClient.java:988)
        at com.algolia.search.Index.search(Index.java:73)
        at com.algolia.search.Index.search(Index.java:61)
....
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.Float out of START_OBJECT token
 at [Source: java.io.InputStreamReader@369a275c; line: 1, column: 51959] (through reference chain: com.algolia.search.responses.SearchResult["facets_stats"]->java.util.LinkedHashMap["staticFeatures_price"])
        at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:270)
```

This PR contains the right model:`Map<String, Map<String, Float>> facets_stats;`