### PR TITLE
Make number of concurrent HTTP connections larger then 2

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/ApacheHttpClient.java
+++ b/algoliasearch/src/main/java/com/algolia/search/ApacheHttpClient.java
@@ -66,7 +66,8 @@ public class ApacheHttpClient extends AlgoliaHttpClient {
             .setDefaultHeaders(httpHeaders)
             .setDnsResolver(new TimeoutableHostNameResolver(configuration.getConnectTimeout()))
             .setDefaultRequestConfig(requestConfigBuilder.build())
-            .setMaxConnTotal(configuration.getMaxConnTotal());
+            .setMaxConnPerRoute(configuration.getMaxConnTotal())
+            .setMaxConnTotal(2 * configuration.getMaxConnTotal());
 
     if (httpClientConfiguration.getDefaultCredentialsProvider() != null) {
       httpClientBuilder =


### PR DESCRIPTION
### What will merging this PR change?
This PR will change the meaning of `maxConnTotal` in the blocking client to be _per route_, and the maximum amount of connection to twice that.

In the _current_ implementation, the maximum amount of concurrent http requests to the Algolia API is always **2**, regardless of the value defined in `maxConnTotal`. 

### Motivation
From the HTTP Components docs:  

> `PoolingHttpClientConnectionManager` maintains a maximum limit of connections on a per route basis and in total. Per default this implementation will create no more than 2 concurrent connections per given route and no more 20 connections in total. For many real-world applications these limits may prove too constraining, especially if they use HTTP as a transport protocol for their services.

In the current implementation, there is a setting `maxConnTotal`, which is supposed to change the maximum concurrent connections. The default (defined in `GenericAPIClientBuilder`) for this setting is `10`. 

This setting currently does not have the expected effect. In practice, all requests go to the same _route_ (`*-dsn.algolia.net`), meaning the maximum amount of concurrent requests is always **2**. This greatly hinders concurrent performance. 

### Benchmark
As an illustration, this is what happens when making 200 requests with a concurrency level of 50, through the blocking sdk client. 

Before this change, maxConnTotal = 100: 
```
Response time histogram:
  0.205 [1]	|∎
  0.584 [3]	|∎∎
  0.962 [11]	|∎∎∎∎∎∎∎
  1.341 [40]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  1.720 [61]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  2.098 [38]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  2.477 [14]	|∎∎∎∎∎∎∎∎∎
  2.855 [8]	|∎∎∎∎∎
  3.234 [13]	|∎∎∎∎∎∎∎∎∎
  3.613 [4]	|∎∎∎
  3.991 [7]	|∎∎∎∎∎
```

After this change: maxConnTotal = 100: 
```
Response time histogram:
  0.015 [1]	|
  0.032 [136]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.048 [32]	|∎∎∎∎∎∎∎∎∎
  0.065 [10]	|∎∎∎
  0.082 [2]	|∎
  0.098 [2]	|∎
  0.115 [2]	|∎
  0.132 [5]	|∎
  0.149 [4]	|∎
  0.165 [4]	|∎
  0.182 [2]	|∎`
```

### Alternatives
We could also decide to set `useSystemProperties` on `HttpClientBuilder`, which will allow for the system properties `http.maxConnections` and `http.keepAlive` to be honored by the client. One thing to be aware of is that we should then remove the default in `GenericAPIClientBuilder`, as this will override the maximum total amount of connections, but not the maximum per route, resulting in unexpected behaviour.
