### PR TITLE
fix: Prevent saving a rule with an empty objectID

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -1260,6 +1260,10 @@ public class APIClient {
       Boolean forwardToReplicas,
       RequestOptions requestOptions)
       throws AlgoliaException {
+    if (ruleId.isEmpty()) {
+        throw new AlgoliaException("Cannot save rule with empty queryRuleID");
+    }
+
     Task task =
         httpClient.requestWithRetry(
             new AlgoliaRequest<>(

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -1172,6 +1172,11 @@ public class AsyncAPIClient {
       Rule queryRule,
       Boolean forwardToReplicas,
       RequestOptions requestOptions) {
+    if (queryRuleID.isEmpty()) {
+      CompletableFuture f = new CompletableFuture<>();
+      f.completeExceptionally(new AlgoliaException("Cannot save rule with empty queryRuleID"));
+      return f;
+    }
     return httpClient
         .requestWithRetry(
             new AlgoliaRequest<>(

--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncRules.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncRules.java
@@ -67,6 +67,9 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
       boolean forwardToReplicas,
       @Nonnull RequestOptions requestOptions)
       throws AlgoliaException {
+    if (queryRuleID.isEmpty()) {
+      throw new AlgoliaException("Cannot save rule with empty queryRuleID");
+    }
     return getApiClient()
         .saveRule(getName(), queryRuleID, content, forwardToReplicas, requestOptions);
   }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncRulesTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncRulesTest.java
@@ -1,6 +1,7 @@
 package com.algolia.search.integration.common.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.algolia.search.AsyncAlgoliaIntegrationTest;
 import com.algolia.search.AsyncIndex;
@@ -8,6 +9,7 @@ import com.algolia.search.inputs.query_rules.Condition;
 import com.algolia.search.inputs.query_rules.Consequence;
 import com.algolia.search.inputs.query_rules.Rule;
 import com.algolia.search.objects.RuleQuery;
+import com.algolia.search.objects.tasks.async.AsyncTask;
 import com.algolia.search.responses.SearchRuleResult;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
@@ -37,6 +39,15 @@ public abstract class AsyncRulesTest extends AsyncAlgoliaIntegrationTest {
         .isInstanceOf(Rule.class)
         .isEqualToComparingFieldByFieldRecursively(generateRule(ruleID));
   }
+
+  @Test
+  public void trySaveRuleWithEmptyObjectID() throws Exception {
+    AsyncIndex<?> index = createIndex();
+
+    assertThatThrownBy(
+        () -> index.saveRule("", generateRule("")).get()
+    ).hasMessageContaining("Cannot save rule with empty queryRuleID");
+}
 
   @Test
   public void deleteQueryRule() throws Exception {

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncRulesTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncRulesTest.java
@@ -1,12 +1,14 @@
 package com.algolia.search.integration.common.sync;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.algolia.search.Index;
 import com.algolia.search.SyncAlgoliaIntegrationTest;
 import com.algolia.search.exceptions.AlgoliaException;
 import com.algolia.search.inputs.query_rules.Rule;
 import com.algolia.search.objects.RuleQuery;
+import com.algolia.search.objects.tasks.sync.Task;
 import com.algolia.search.responses.SearchRuleResult;
 import java.util.Arrays;
 import java.util.Optional;
@@ -27,6 +29,15 @@ public abstract class SyncRulesTest extends SyncAlgoliaIntegrationTest {
     assertThat(queryRule1.get())
         .isInstanceOf(Rule.class)
         .isEqualToComparingFieldByFieldRecursively(generateRule(ruleId));
+  }
+
+  @Test
+  public void trySaveRuleWithEmptyObjectID() throws Exception {
+    Index<?> index = createIndex();
+
+    assertThatThrownBy(
+        () -> index.saveRule("", generateRule(""))
+    ).hasMessageContaining("Cannot save rule with empty queryRuleID");
   }
 
   @Test


### PR DESCRIPTION
Follow up of https://github.com/algolia/algoliasearch-client-go/issues/397.