### PR TITLE
Added queryid field to SearchResult

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/responses/SearchResult.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/responses/SearchResult.java
@@ -34,6 +34,8 @@ public class SearchResult<T> implements Serializable {
 
   private Boolean processed;
 
+  private String queryID;
+
   public List<T> getHits() {
     return hits;
   }
@@ -164,6 +166,15 @@ public class SearchResult<T> implements Serializable {
 
   public SearchResult<T> setProcessed(Boolean processed) {
     this.processed = processed;
+    return this;
+  }
+
+  public String getQueryID() {
+    return queryID;
+  }
+
+  public SearchResult<T> setQueryID(final String queryID) {
+    this.queryID = queryID;
     return this;
   }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          |  yes
| New feature?      | no   
| BC breaks?        | no     
| Need Doc update   | no


## What was changed
 queryid field has been added to SearchResult class. 


## Why it was changed
Queryid field value is returned with search results when  query has parameter  clickAnalytics = true. QueryId value is used to capture click +rates and conversions. 
