### PR TITLE
fix: Avoid infinite serialization recursion of `ConsequenceQuery`

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/ConsequenceQuery.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/ConsequenceQuery.java
@@ -1,46 +1,7 @@
 package com.algolia.search.inputs.query_rules;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.io.IOException;
 import java.io.Serializable;
 
-@SuppressWarnings("WeakerAccess")
-@JsonDeserialize(using = ConsequenceQueryDeserializer.class)
-@JsonSerialize(using = ConsequenceQuerySerializer.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class ConsequenceQuery implements Serializable {}
-
-class ConsequenceQueryDeserializer extends JsonDeserializer<ConsequenceQuery> {
-
-  @Override
-  public ConsequenceQuery deserialize(JsonParser p, DeserializationContext ctxt)
-      throws IOException {
-    JsonToken currentToken = p.getCurrentToken();
-    if (currentToken.equals(JsonToken.VALUE_STRING)) {
-      return new ConsequenceQueryString(p.getValueAsString());
-    }
-
-    JavaType jacksonType = ctxt.getTypeFactory().constructType(ConsequenceQueryObject.class);
-    JsonDeserializer<?> deserializer = ctxt.findRootValueDeserializer(jacksonType);
-    return (ConsequenceQueryObject) deserializer.deserialize(p, ctxt);
-  }
-}
-
-class ConsequenceQuerySerializer extends JsonSerializer<ConsequenceQuery> {
-
-  @Override
-  public void serialize(ConsequenceQuery value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
-    if (value instanceof ConsequenceQueryString) {
-      gen.writeString(((ConsequenceQueryString) value).getQuery());
-    } else {
-      gen.writeObject(value);
-    }
-  }
-}

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncRulesTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncRulesTest.java
@@ -1,21 +1,22 @@
 package com.algolia.search.integration.common.sync;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.algolia.search.Index;
 import com.algolia.search.SyncAlgoliaIntegrationTest;
 import com.algolia.search.exceptions.AlgoliaException;
-import com.algolia.search.inputs.query_rules.Rule;
+import com.algolia.search.inputs.query_rules.*;
 import com.algolia.search.objects.Query;
 import com.algolia.search.objects.RuleQuery;
 import com.algolia.search.responses.SearchResult;
 import com.algolia.search.responses.SearchRuleResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
-
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.Test;
 
 class DummyRecord {
   private String objectID;
@@ -118,5 +119,33 @@ public abstract class SyncRulesTest extends SyncAlgoliaIntegrationTest {
 
     SearchRuleResult searchResult = index.searchRules(new RuleQuery(""));
     assertThat(searchResult.getHits()).hasSize(2);
+  }
+
+  @Test
+  public void queryRuleSerialization() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    Condition condition =
+        new Condition().setPattern("{facet:products.properties.fbrand}").setAnchoring("contains");
+
+    ConsequenceQueryObject consequenceQuery =
+        new ConsequenceQueryObject()
+            .setRemove(Collections.singletonList("{facet:products.properties.fbrand}"));
+
+    ConsequenceParams params =
+        new ConsequenceParams()
+            .setAutomaticFacetFilters(Collections.singletonList("products.properties.fbrand"));
+
+    params.setQuery(consequenceQuery);
+    Consequence consequence = new Consequence().setParams(params);
+
+    Rule rule1 =
+        new Rule()
+            .setObjectID("1528811588947")
+            .setDescription("Boost Brands")
+            .setCondition(condition)
+            .setConsequence(consequence);
+
+    objectMapper.writeValueAsString(rule1);
   }
 }


### PR DESCRIPTION
Closes #492