### PR TITLE
Fix facet filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ hs_err_pid*
 *.iml
 .DS_Store
 *.logQueryTest
+
+.factorypath

--- a/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/ConsequenceParams.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/ConsequenceParams.java
@@ -192,11 +192,17 @@ public class ConsequenceParams extends Query {
     return (ConsequenceParams) super.setMaxValuesPerFacet(maxValuesPerFacet);
   }
 
-  public List<String> getFacetFilters() {
+  public FacetFilters getFacetFilters() {
     return facetFilters;
   }
 
+  @Deprecated
   public ConsequenceParams setFacetFilters(List<String> facetFilters) {
+    return (ConsequenceParams) super.setFacetFilters(facetFilters);
+  }
+
+  @JsonSetter
+  public ConsequenceParams setFacetFilters(FacetFilters facetFilters) {
     return (ConsequenceParams) super.setFacetFilters(facetFilters);
   }
 

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFilters.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFilters.java
@@ -1,0 +1,68 @@
+package com.algolia.search.objects;
+
+import com.algolia.search.Defaults;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+@JsonDeserialize(using = FacetFiltersJsonDeserializer.class)
+@JsonSerialize(using = FacetFiltersJsonSerializer.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class FacetFilters implements Serializable {
+
+  public static FacetFilters ofList(List<String> filters) {
+    return new FacetFiltersAsListOfString(filters);
+  }
+
+  public static FacetFilters ofListOfList(List<List<String>> filters) {
+    return new FacetFiltersAsListOfList(filters);
+  }
+
+  @JsonIgnore
+  public abstract Object getInsideValue();
+}
+
+class FacetFiltersJsonDeserializer extends JsonDeserializer {
+
+  @Override
+  public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    List list = p.readValueAs(List.class);
+    if (list.isEmpty()) {
+      return new FacetFiltersAsListOfString();
+    }
+    if (list.get(0) instanceof String) {
+      return new FacetFiltersAsListOfString(list);
+    }
+    return new FacetFiltersAsListOfList(list);
+  }
+}
+
+class FacetFiltersJsonSerializer extends JsonSerializer<FacetFilters> {
+
+  @Override
+  public void serialize(FacetFilters value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+
+    ObjectMapper objectMapper = Defaults.DEFAULT_OBJECT_MAPPER;
+
+    if (value instanceof FacetFiltersAsListOfString) {
+      FacetFiltersAsListOfString filters = (FacetFiltersAsListOfString) value;
+      objectMapper.writeValue(gen, filters.getFilters());
+
+    } else if (value instanceof FacetFiltersAsListOfList) {
+      FacetFiltersAsListOfList filters = (FacetFiltersAsListOfList) value;
+      objectMapper.writeValue(gen, filters.getFilters());
+
+    } else {
+      throw new IOException(
+          "cannot serialize facetFilters: unknown input type '" + value.getClass().getName() + "'");
+    }
+  }
+}

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFiltersAsListOfList.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFiltersAsListOfList.java
@@ -1,0 +1,25 @@
+package com.algolia.search.objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
+
+@JsonDeserialize(as = FacetFiltersAsListOfList.class)
+public class FacetFiltersAsListOfList extends FacetFilters {
+
+  private List<List<String>> filters;
+
+  FacetFiltersAsListOfList(List<List<String>> filters) {
+    this.filters = filters;
+  }
+
+  @Override
+  @JsonIgnore
+  public Object getInsideValue() {
+    return this.filters;
+  }
+
+  List<List<String>> getFilters() {
+    return this.filters;
+  }
+}

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFiltersAsListOfString.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFiltersAsListOfString.java
@@ -1,0 +1,30 @@
+package com.algolia.search.objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonDeserialize(as = FacetFiltersAsListOfString.class)
+public class FacetFiltersAsListOfString extends FacetFilters {
+
+  private List<String> filters;
+
+  FacetFiltersAsListOfString() {
+    this.filters = new ArrayList<String>();
+  }
+
+  FacetFiltersAsListOfString(List<String> filters) {
+    this.filters = filters;
+  }
+
+  @Override
+  @JsonIgnore
+  public Object getInsideValue() {
+    return this.filters;
+  }
+
+  List<String> getFilters() {
+    return this.filters;
+  }
+}

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/Query.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/Query.java
@@ -37,7 +37,7 @@ public class Query implements Serializable {
   protected String filters;
   protected String facets;
   protected Long maxValuesPerFacet;
-  protected List<String> facetFilters;
+  protected FacetFilters facetFilters;
   protected Boolean facetingAfterDistinct;
   protected String sortFacetValuesBy;
 
@@ -482,11 +482,18 @@ public class Query implements Serializable {
     return this.setMaxValuesPerFacet(maxValuesPerFacet.longValue());
   }
 
-  public List<String> getFacetFilters() {
+  public FacetFilters getFacetFilters() {
     return facetFilters;
   }
 
+  @Deprecated
   public Query setFacetFilters(List<String> facetFilters) {
+    this.facetFilters = new FacetFiltersAsListOfString(facetFilters);
+    return this;
+  }
+
+  @JsonSetter
+  public Query setFacetFilters(FacetFilters facetFilters) {
     this.facetFilters = facetFilters;
     return this;
   }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/objects/FacetFiltersTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/objects/FacetFiltersTest.java
@@ -1,0 +1,36 @@
+package com.algolia.search.objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.algolia.search.Defaults;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class FacetFiltersTest {
+
+  private ObjectMapper objectMapper = Defaults.DEFAULT_OBJECT_MAPPER;
+
+  private FacetFilters serializeDeserialize(FacetFilters facetFilters) throws IOException {
+    String serialized = objectMapper.writeValueAsString(facetFilters);
+    return objectMapper.readValue(
+        serialized, objectMapper.getTypeFactory().constructType(FacetFilters.class));
+  }
+
+  @Test
+  public void facetFiltersAsListOfString() throws IOException {
+    FacetFilters facetFilters = new FacetFiltersAsListOfString(Arrays.asList("filter1", "filter2"));
+    FacetFilters result = serializeDeserialize(facetFilters);
+    assertThat(result).isEqualToComparingFieldByField(facetFilters);
+  }
+
+  @Test
+  public void facetFiltersAsListOfList() throws IOException {
+    FacetFilters facetFilters =
+        new FacetFiltersAsListOfList(
+            Arrays.asList(Arrays.asList("filter1", "filter2"), Arrays.asList("filter3")));
+    FacetFilters result = serializeDeserialize(facetFilters);
+    assertThat(result).isEqualToComparingFieldByField(facetFilters);
+  }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | yes    
| Related Issue     | Fix #505 
| Need Doc update   | yes


## Describe your change

This change introduces a new `FacetFilters` class to replace the `List<String>` type of the `facetFilters` parameter used in the `Query` and in the `ConsequenceParams` (extending `Query`).

## What problem is this fixing?

Currently, because a user can only define `facetFilters` as a list of strings, filters can only be `AND`ed. To be able to `OR` filters, the `facetFilters` should accept lists of list of strings as well. This is what this change is all about. Using the new `FacetFilters` abstract class that is introduced, and its `FacetFiltersAsListOfString`/`FacetFiltersAsListOfList` concrete types, one can easily set the `facetFilters` parameter of a `Query`/`ConsequenceParams` using `List<String>` or `List<List<String>>` types. As any other multi-type object of this Java client, deserialization of object returns an `Object` that can be cast to one of the concrete classes, however, this shouldn't be used that often as the `facetFilters` parameter is only sent but never returned by the API, but anyway, it's doable.

@ElPicador As it's one of the rare times I add custom (de)serializers myself, could you tell me if there's better/more idiomatic ways to write them?