### PR TITLE
changed: default hitsPerPage is 1000 for RulesIteratable

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/iterators/RulesIterable.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/iterators/RulesIterable.java
@@ -11,7 +11,7 @@ public class RulesIterable implements Iterable<Rule> {
   private final Integer hitsPerPage;
 
   public RulesIterable(@Nonnull Index<?> index) {
-    this(index, 10000);
+    this(index, 1000);
   }
 
   public RulesIterable(@Nonnull Index<?> index, @Nonnull Integer hitsPerPage) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

When creating a RulesIteratable via `RulesIterable(index)` (without specifying the hitsPerPage) the API client use the default value of 10,000. The limit of the Algolia API is 1,000.

I believe this was a typo, my commit fixes it.
