### PR TITLE
Fix: objectID is required to deleteObject

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -807,6 +807,12 @@ public class APIClient {
 
   Task deleteObject(String indexName, String objectID, RequestOptions requestOptions)
       throws AlgoliaException {
+
+    if (objectID.trim().length() == 0)
+    {
+      throw new AlgoliaException("ObjectID must not be empty");
+    }
+
     Task result =
         httpClient.requestWithRetry(
             new AlgoliaRequest<>(

--- a/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/APIClient.java
@@ -808,9 +808,8 @@ public class APIClient {
   Task deleteObject(String indexName, String objectID, RequestOptions requestOptions)
       throws AlgoliaException {
 
-    if (objectID.trim().length() == 0)
-    {
-      throw new AlgoliaException("ObjectID must not be empty");
+    if (objectID.trim().length() == 0) {
+      throw new IllegalArgumentException("ObjectID must not be empty");
     }
 
     Task result =

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -788,8 +788,14 @@ public class AsyncAPIClient {
         .thenApply(s -> s.setIndex(indexName));
   }
 
-  CompletableFuture<AsyncTask> deleteObject(
-      String indexName, String objectID, RequestOptions requestOptions) {
+  CompletableFuture<AsyncTask> deleteObject (
+      String indexName, String objectID, RequestOptions requestOptions) throws AlgoliaException {
+
+    if (objectID.trim().length() == 0)
+    {
+      throw new AlgoliaException("ObjectID must not be empty");
+    }
+
     return httpClient
         .requestWithRetry(
             new AlgoliaRequest<>(

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncAPIClient.java
@@ -788,12 +788,11 @@ public class AsyncAPIClient {
         .thenApply(s -> s.setIndex(indexName));
   }
 
-  CompletableFuture<AsyncTask> deleteObject (
-      String indexName, String objectID, RequestOptions requestOptions) throws AlgoliaException {
+  CompletableFuture<AsyncTask> deleteObject(
+      String indexName, String objectID, RequestOptions requestOptions) {
 
-    if (objectID.trim().length() == 0)
-    {
-      throw new AlgoliaException("ObjectID must not be empty");
+    if (objectID.trim().length() == 0) {
+      throw new IllegalArgumentException("ObjectID must not be empty");
     }
 
     return httpClient

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncObjects.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncObjects.java
@@ -1,6 +1,5 @@
 package com.algolia.search;
 
-import com.algolia.search.exceptions.AlgoliaException;
 import com.algolia.search.objects.RequestOptions;
 import com.algolia.search.objects.tasks.async.AsyncTask;
 import com.algolia.search.objects.tasks.async.AsyncTaskIndexing;
@@ -207,7 +206,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * @param objectID the unique identifier of the object to retrieve
    * @return the associated AsyncTask
    */
-  default CompletableFuture<AsyncTask> deleteObject(@Nonnull String objectID) throws AlgoliaException {
+  default CompletableFuture<AsyncTask> deleteObject(@Nonnull String objectID) {
     return deleteObject(objectID, RequestOptions.empty);
   }
 
@@ -218,8 +217,8 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * @param requestOptions Options to pass to this request
    * @return the associated AsyncTask
    */
-  default CompletableFuture<AsyncTask> deleteObject (
-      @Nonnull String objectID, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
+  default CompletableFuture<AsyncTask> deleteObject(
+      @Nonnull String objectID, @Nonnull RequestOptions requestOptions) {
     return getApiClient().deleteObject(getName(), objectID, requestOptions);
   }
 

--- a/algoliasearch-common/src/main/java/com/algolia/search/AsyncObjects.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/AsyncObjects.java
@@ -1,5 +1,6 @@
 package com.algolia.search;
 
+import com.algolia.search.exceptions.AlgoliaException;
 import com.algolia.search.objects.RequestOptions;
 import com.algolia.search.objects.tasks.async.AsyncTask;
 import com.algolia.search.objects.tasks.async.AsyncTaskIndexing;
@@ -206,7 +207,7 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * @param objectID the unique identifier of the object to retrieve
    * @return the associated AsyncTask
    */
-  default CompletableFuture<AsyncTask> deleteObject(@Nonnull String objectID) {
+  default CompletableFuture<AsyncTask> deleteObject(@Nonnull String objectID) throws AlgoliaException {
     return deleteObject(objectID, RequestOptions.empty);
   }
 
@@ -217,8 +218,8 @@ public interface AsyncObjects<T> extends AsyncBaseIndex<T> {
    * @param requestOptions Options to pass to this request
    * @return the associated AsyncTask
    */
-  default CompletableFuture<AsyncTask> deleteObject(
-      @Nonnull String objectID, @Nonnull RequestOptions requestOptions) {
+  default CompletableFuture<AsyncTask> deleteObject (
+      @Nonnull String objectID, @Nonnull RequestOptions requestOptions) throws AlgoliaException {
     return getApiClient().deleteObject(getName(), objectID, requestOptions);
   }
 

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncObjectsTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncObjectsTest.java
@@ -11,8 +11,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
-import com.algolia.search.exceptions.AlgoliaException;
 import org.junit.Test;
 
 @SuppressWarnings("ConstantConditions")
@@ -135,20 +133,20 @@ public abstract class AsyncObjectsTest extends AsyncAlgoliaIntegrationTest {
     futureAssertThat(result).extracting("name").containsNull();
   }
 
-  @Test(expected = AlgoliaException.class)
-  public void deleteObjectEmptyObjectIdShouldFail() throws AlgoliaException {
+  @Test(expected = IllegalArgumentException.class)
+  public void deleteObjectEmptyObjectIdShouldFail() throws IllegalArgumentException {
     AsyncIndex<AlgoliaObject> index = createIndex(AlgoliaObject.class);
     index.deleteObject("");
   }
 
-  @Test(expected = AlgoliaException.class)
-  public void deleteObjectWhiteSpaceObjectIdShouldFail() throws AlgoliaException {
+  @Test(expected = IllegalArgumentException.class)
+  public void deleteObjectWhiteSpaceObjectIdShouldFail() throws IllegalArgumentException {
     AsyncIndex<AlgoliaObject> index = createIndex(AlgoliaObject.class);
     index.deleteObject("  ");
   }
 
   @Test(expected = NullPointerException.class)
-  public void deleteObjectNullObjectIdShouldFail() throws AlgoliaException {
+  public void deleteObjectNullObjectIdShouldFail() throws NullPointerException {
     AsyncIndex<AlgoliaObject> index = createIndex(AlgoliaObject.class);
     index.deleteObject(null);
   }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncObjectsTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncObjectsTest.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+
+import com.algolia.search.exceptions.AlgoliaException;
 import org.junit.Test;
 
 @SuppressWarnings("ConstantConditions")
@@ -131,5 +133,23 @@ public abstract class AsyncObjectsTest extends AsyncAlgoliaIntegrationTest {
 
     futureAssertThat(result).hasSize(1);
     futureAssertThat(result).extracting("name").containsNull();
+  }
+
+  @Test(expected = AlgoliaException.class)
+  public void deleteObjectEmptyObjectIdShouldFail() throws AlgoliaException {
+    AsyncIndex<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+    index.deleteObject("");
+  }
+
+  @Test(expected = AlgoliaException.class)
+  public void deleteObjectWhiteSpaceObjectIdShouldFail() throws AlgoliaException {
+    AsyncIndex<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+    index.deleteObject("  ");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void deleteObjectNullObjectIdShouldFail() throws AlgoliaException {
+    AsyncIndex<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+    index.deleteObject(null);
   }
 }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncObjectsTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncObjectsTest.java
@@ -131,20 +131,22 @@ public abstract class SyncObjectsTest extends SyncAlgoliaIntegrationTest {
         .isEqualToComparingFieldByField(new AlgoliaObjectWithID("1", null, 5));
   }
 
-  @Test(expected = AlgoliaException.class)
-  public void deleteObjectEmptyObjectIdShouldFail() throws AlgoliaException {
+  @Test(expected = IllegalArgumentException.class)
+  public void deleteObjectEmptyObjectIdShouldFail()
+      throws AlgoliaException, IllegalArgumentException {
     Index<AlgoliaObject> index = createIndex(AlgoliaObject.class);
     index.deleteObject("");
   }
 
-  @Test(expected = AlgoliaException.class)
-  public void deleteObjectWhiteSpaceObjectIdShouldFail() throws AlgoliaException {
+  @Test(expected = IllegalArgumentException.class)
+  public void deleteObjectWhiteSpaceObjectIdShouldFail()
+      throws AlgoliaException, IllegalArgumentException {
     Index<AlgoliaObject> index = createIndex(AlgoliaObject.class);
     index.deleteObject("  ");
   }
 
   @Test(expected = NullPointerException.class)
-  public void deleteObjectNullObjectIdShouldFail() throws AlgoliaException {
+  public void deleteObjectNullObjectIdShouldFail() throws AlgoliaException, NullPointerException {
     Index<AlgoliaObject> index = createIndex(AlgoliaObject.class);
     index.deleteObject(null);
   }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncObjectsTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncObjectsTest.java
@@ -130,4 +130,22 @@ public abstract class SyncObjectsTest extends SyncAlgoliaIntegrationTest {
     assertThat(objects.get(0))
         .isEqualToComparingFieldByField(new AlgoliaObjectWithID("1", null, 5));
   }
+
+  @Test(expected = AlgoliaException.class)
+  public void deleteObjectEmptyObjectIdShouldFail() throws AlgoliaException {
+    Index<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+    index.deleteObject("");
+  }
+
+  @Test(expected = AlgoliaException.class)
+  public void deleteObjectWhiteSpaceObjectIdShouldFail() throws AlgoliaException {
+    Index<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+    index.deleteObject("  ");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void deleteObjectNullObjectIdShouldFail() throws AlgoliaException {
+    Index<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+    index.deleteObject(null);
+  }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change
`index.deleteObject` needs a non-empty/null objectID

## What problem is this fixing?
If the objectID is empty, the entire index will be deleted instead of one record.

