### PR TITLE
make FacetFilters implement CompoundType

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFilters.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/FacetFilters.java
@@ -15,7 +15,7 @@ import java.util.List;
 @JsonDeserialize(using = FacetFiltersJsonDeserializer.class)
 @JsonSerialize(using = FacetFiltersJsonSerializer.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class FacetFilters implements Serializable {
+public abstract class FacetFilters implements Serializable, CompoundType {
 
   public static FacetFilters ofList(List<String> filters) {
     return new FacetFiltersAsListOfString(filters);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #522 
| Need Doc update   | no


## Describe your change
FacetFilters should implement CompoundType so Query.toQueryParam() knows how to add FacetFilters to the params String.

## What problem is this fixing?
Searching using FacetFilters fails as the toString() method of FacetFilters is used to append the facet filters to the query params, which uses a raw Java toString() rather than something sensible.