### PR TITLE
Fixed: GeoSearch insideBounding and insidePolygon types

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/QueryBase.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/QueryBase.java
@@ -65,8 +65,8 @@ public abstract class QueryBase<T extends QueryBase<?>> implements Serializable 
   protected AroundRadius aroundRadius;
   protected Integer aroundPrecision;
   protected Integer minimumAroundRadius;
-  protected List<String> insideBoundingBox;
-  protected List<String> insidePolygon;
+  protected List<List<Float>> insideBoundingBox;
+  protected List<List<Float>> insidePolygon;
 
   /* highlighting-snippeting */
   protected List<String> attributesToHighlight;
@@ -575,20 +575,20 @@ public abstract class QueryBase<T extends QueryBase<?>> implements Serializable 
     return (T) this;
   }
 
-  public List<String> getInsideBoundingBox() {
+  public List<List<Float>> getInsideBoundingBox() {
     return insideBoundingBox;
   }
 
-  public T setInsideBoundingBox(List<String> insideBoundingBox) {
+  public T setInsideBoundingBox(List<List<Float>> insideBoundingBox) {
     this.insideBoundingBox = insideBoundingBox;
     return (T) this;
   }
 
-  public List<String> getInsidePolygon() {
+  public List<List<Float>> getInsidePolygon() {
     return insidePolygon;
   }
 
-  public T setInsidePolygon(List<String> insidePolygon) {
+  public T setInsidePolygon(List<List<Float>> insidePolygon) {
     this.insidePolygon = insidePolygon;
     return (T) this;
   }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncSearchTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/async/AsyncSearchTest.java
@@ -131,4 +131,86 @@ public abstract class AsyncSearchTest extends AsyncAlgoliaIntegrationTest {
     SearchFacetResult result = index.searchForFacetValues("series", "Peanuts").get();
     assertThat(result.getFacetHits()).hasSize(1);
   }
+
+  @Test
+  public void geoSearch() throws Exception {
+    AsyncIndex<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+
+    waitForCompletion(
+        index.addObjects(
+            Arrays.asList(
+                new AlgoliaObject("algolia1", 1),
+                new AlgoliaObject("algolia2", 1),
+                new AlgoliaObject("toto", 1))));
+
+    SearchResult<AlgoliaObject> searchInsideBounding =
+        index
+            .search(
+                new Query("algolia")
+                    .setInsideBoundingBox(
+                        Arrays.asList(
+                            Arrays.asList(
+                                46.650828100116044f,
+                                7.123046875f,
+                                45.17210966999772f,
+                                1.009765625f))))
+            .get();
+
+    SearchResult<AlgoliaObject> searchInsindeBoundingList =
+        index
+            .search(
+                new Query("algolia")
+                    .setInsideBoundingBox(
+                        Arrays.asList(
+                            Arrays.asList(
+                                46.650828100116044f,
+                                7.123046875f,
+                                45.17210966999772f,
+                                1.009765625f),
+                            Arrays.asList(
+                                49.62625916704081f,
+                                4.6181640625f,
+                                47.715070300900194f,
+                                0.482421875f))))
+            .get();
+
+    SearchResult<AlgoliaObject> searchInsidePolygon =
+        index
+            .search(
+                new Query("algolia")
+                    .setInsidePolygon(
+                        Arrays.asList(
+                            Arrays.asList(
+                                46.650828100116044f,
+                                7.123046875f,
+                                45.17210966999772f,
+                                1.009765625f,
+                                49.62625916704081f,
+                                4.6181640625f))))
+            .get();
+
+    SearchResult<AlgoliaObject> searchInsidePolygonList =
+        index
+            .search(
+                new Query("algolia")
+                    .setInsidePolygon(
+                        Arrays.asList(
+                            Arrays.asList(
+                                46.650828100116044f,
+                                7.123046875f,
+                                45.17210966999772f,
+                                1.009765625f,
+                                49.62625916704081f,
+                                4.6181640625f),
+                            Arrays.asList(
+                                49.62625916704081f,
+                                4.6181640625f,
+                                47.715070300900194f,
+                                0.482421875f,
+                                45.17210966999772f,
+                                1.009765625f,
+                                50.62626704081f,
+                                4.6181640625f))))
+            .get();
+  }
 }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncSearchTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/integration/common/sync/SyncSearchTest.java
@@ -138,4 +138,74 @@ public abstract class SyncSearchTest extends SyncAlgoliaIntegrationTest {
         ImmutableMap.of("age", new FacetStats().setMax(30f).setMin(10f).setSum(60f).setAvg(20f));
     assertThat(search.getFacets_stats()).isEqualToComparingFieldByFieldRecursively(expected);
   }
+
+  @Test
+  public void geoSearch() throws AlgoliaException {
+    Index<AlgoliaObject> index = createIndex(AlgoliaObject.class);
+
+    waitForCompletion(
+        index.addObjects(
+            Arrays.asList(
+                new AlgoliaObject("algolia1", 1),
+                new AlgoliaObject("algolia2", 1),
+                new AlgoliaObject("toto", 1))));
+
+    SearchResult<AlgoliaObject> searchInsideBounding =
+        index.search(
+            new Query("algolia")
+                .setInsideBoundingBox(
+                    Arrays.asList(
+                        Arrays.asList(
+                            46.650828100116044f, 7.123046875f, 45.17210966999772f, 1.009765625f))));
+
+    searchInsideBounding.getParams();
+
+    SearchResult<AlgoliaObject> searchInsindeBoundingList =
+        index.search(
+            new Query("algolia")
+                .setInsideBoundingBox(
+                    Arrays.asList(
+                        Arrays.asList(
+                            46.650828100116044f, 7.123046875f, 45.17210966999772f, 1.009765625f),
+                        Arrays.asList(
+                            49.62625916704081f,
+                            4.6181640625f,
+                            47.715070300900194f,
+                            0.482421875f))));
+
+    SearchResult<AlgoliaObject> searchInsidePolygon =
+        index.search(
+            new Query("algolia")
+                .setInsidePolygon(
+                    Arrays.asList(
+                        Arrays.asList(
+                            46.650828100116044f,
+                            7.123046875f,
+                            45.17210966999772f,
+                            1.009765625f,
+                            49.62625916704081f,
+                            4.6181640625f))));
+
+    SearchResult<AlgoliaObject> searchInsidePolygonList =
+        index.search(
+            new Query("algolia")
+                .setInsidePolygon(
+                    Arrays.asList(
+                        Arrays.asList(
+                            46.650828100116044f,
+                            7.123046875f,
+                            45.17210966999772f,
+                            1.009765625f,
+                            49.62625916704081f,
+                            4.6181640625f),
+                        Arrays.asList(
+                            49.62625916704081f,
+                            4.6181640625f,
+                            47.715070300900194f,
+                            0.482421875f,
+                            45.17210966999772f,
+                            1.009765625f,
+                            50.62626704081f,
+                            4.6181640625f))));
+  }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | yes     
| Need Doc update   | yes

## Describe your change

Replaced in the `QueryBase` class the type of `insideBoundingBox` and `insidePolygon` from `List<String>` to `List<List<Float>>`

## What problem is this fixing?

We were not able to perfom geosearch with `List<String>`we were getting error from the API.