### PR TITLE
Fix several types when serializing/deserializing

### DIFF
--- a/algoliasearch-tests/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -119,11 +119,11 @@ public class JacksonParserTest {
     settings =
         new IndexSettings().setIgnorePlurals(IgnorePlurals.of(Collections.singletonList("en")));
     assertThat(DEFAULT_OBJECT_MAPPER.writeValueAsString(settings))
-        .isEqualTo("{\"ignorePlurals\":\"en\"}");
+        .isEqualTo("{\"ignorePlurals\":[\"en\"]}");
 
     settings = new IndexSettings().setIgnorePlurals(Arrays.asList("en", "fr"));
     assertThat(DEFAULT_OBJECT_MAPPER.writeValueAsString(settings))
-        .isEqualTo("{\"ignorePlurals\":\"en,fr\"}");
+        .isEqualTo("{\"ignorePlurals\":[\"en\",\"fr\"]}");
   }
 
   @Test
@@ -138,13 +138,13 @@ public class JacksonParserTest {
 
     ignorePlurals =
         DEFAULT_OBJECT_MAPPER
-            .readValue("{\"ignorePlurals\":\"en\"}", IndexSettings.class)
+            .readValue("{\"ignorePlurals\":[\"en\"]}", IndexSettings.class)
             .getIgnorePlurals();
     assertThat(ignorePlurals).isEqualTo(IgnorePlurals.of(Collections.singletonList("en")));
 
     ignorePlurals =
         DEFAULT_OBJECT_MAPPER
-            .readValue("{\"ignorePlurals\":\"en,fr\"}", IndexSettings.class)
+            .readValue("{\"ignorePlurals\":[\"en\",\"fr\"]}", IndexSettings.class)
             .getIgnorePlurals();
     assertThat(ignorePlurals).isEqualTo(IgnorePlurals.of(Arrays.asList("en", "fr")));
   }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | so


## Describe your change

* Fix serialization/deserialization of `ignorePlurals`

## What problem is this fixing?

Because wrong types where used when serializing/deserializing, some parameters or types could not be used properly.