### PR TITLE
tests: Split "core" and "apache"

### DIFF
--- a/src/main/java/com/algolia/search/ApacheHttpRequester.java
+++ b/src/main/java/com/algolia/search/ApacheHttpRequester.java
@@ -30,13 +30,13 @@ import org.apache.http.util.EntityUtils;
  * implementation of {@link HttpRequester} It takes an {@link HttpRequest} as input. It returns an
  * {@link HttpResponse}.
  */
-class ApacheHttpRequester implements HttpRequester {
+public class ApacheHttpRequester implements HttpRequester {
 
   private final CloseableHttpAsyncClient asyncHttpClient;
   private final RequestConfig requestConfig;
   private final ConfigBase config;
 
-  ApacheHttpRequester(@Nonnull ConfigBase config) {
+  public ApacheHttpRequester(@Nonnull ConfigBase config) {
 
     this.config = config;
 

--- a/src/test/java/com/algolia/search/apache/account/AccountCopyTest.java
+++ b/src/test/java/com/algolia/search/apache/account/AccountCopyTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.account;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class AccountCopyTest extends com.algolia.search.integration.account.AccountCopyTest {
+  AccountCopyTest() {
+    super(IntegrationTestExtension.searchClient, IntegrationTestExtension.searchClient2);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/analytics/AnalyticsTest.java
+++ b/src/test/java/com/algolia/search/apache/analytics/AnalyticsTest.java
@@ -1,0 +1,27 @@
+package com.algolia.search.apache.analytics;
+
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+
+import com.algolia.search.AnalyticsClient;
+import com.algolia.search.integration.IntegrationTestExtension;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AnalyticsTest extends com.algolia.search.integration.analytics.AnalyticsTest {
+
+  AnalyticsTest() {
+    super(
+        IntegrationTestExtension.searchClient,
+        new AnalyticsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1));
+  }
+
+  @AfterAll
+  void afterAll() throws IOException {
+    analyticsClient.close();
+  }
+}

--- a/src/test/java/com/algolia/search/apache/analytics/AnalyticsTest.java
+++ b/src/test/java/com/algolia/search/apache/analytics/AnalyticsTest.java
@@ -7,21 +7,20 @@ import com.algolia.search.AnalyticsClient;
 import com.algolia.search.integration.IntegrationTestExtension;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AnalyticsTest extends com.algolia.search.integration.analytics.AnalyticsTest {
 
+  private static AnalyticsClient analyticsClient =
+      new AnalyticsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+
   AnalyticsTest() {
-    super(
-        IntegrationTestExtension.searchClient,
-        new AnalyticsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1));
+    super(IntegrationTestExtension.searchClient, analyticsClient);
   }
 
   @AfterAll
-  void afterAll() throws IOException {
+  static void afterAll() throws IOException {
     analyticsClient.close();
   }
 }

--- a/src/test/java/com/algolia/search/apache/client/ApiKeysTest.java
+++ b/src/test/java/com/algolia/search/apache/client/ApiKeysTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.client;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class ApiKeysTest extends com.algolia.search.integration.client.ApiKeysTest {
+  ApiKeysTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/client/CopyIndexTest.java
+++ b/src/test/java/com/algolia/search/apache/client/CopyIndexTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.client;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class CopyIndexTest extends com.algolia.search.integration.client.CopyIndexTest {
+  CopyIndexTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/client/LogsTest.java
+++ b/src/test/java/com/algolia/search/apache/client/LogsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.client;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class LogsTest extends com.algolia.search.integration.client.LogsTest {
+  LogsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/client/MultiClusterManagementTest.java
+++ b/src/test/java/com/algolia/search/apache/client/MultiClusterManagementTest.java
@@ -1,0 +1,26 @@
+package com.algolia.search.apache.client;
+
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_ADMIN_KEY_MCM;
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_MCM;
+
+import com.algolia.search.SearchClient;
+import com.algolia.search.integration.IntegrationTestExtension;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MultiClusterManagementTest
+    extends com.algolia.search.integration.client.MultiClusterManagementTest {
+
+  MultiClusterManagementTest() {
+    super(new SearchClient(ALGOLIA_APPLICATION_ID_MCM, ALGOLIA_ADMIN_KEY_MCM));
+  }
+
+  @AfterAll
+  void afterAll() throws IOException {
+    mcmClient.close();
+  }
+}

--- a/src/test/java/com/algolia/search/apache/client/MultipleOperationsTest.java
+++ b/src/test/java/com/algolia/search/apache/client/MultipleOperationsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.client;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class MultipleOperationsTest extends com.algolia.search.integration.client.MultipleOperationsTest {
+  MultipleOperationsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/client/SecuredAPIKeyTest.java
+++ b/src/test/java/com/algolia/search/apache/client/SecuredAPIKeyTest.java
@@ -1,0 +1,23 @@
+package com.algolia.search.apache.client;
+
+import static com.algolia.search.integration.IntegrationTestExtension.*;
+
+import com.algolia.search.SearchClient;
+import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.models.apikeys.SecuredApiKeyRestriction;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SecuredAPIKeyTest extends com.algolia.search.integration.client.SecuredAPIKeyTest {
+
+  SecuredAPIKeyTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+
+  @Override
+  protected SearchClient createClientWithRestriction(SecuredApiKeyRestriction restriction)
+      throws Exception {
+    String key = searchClient.generateSecuredAPIKey(ALGOLIA_SEARCH_KEY_1, restriction);
+    return new SearchClient(ALGOLIA_APPLICATION_ID_1, key);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/client/TimeoutTest.java
+++ b/src/test/java/com/algolia/search/apache/client/TimeoutTest.java
@@ -1,0 +1,18 @@
+package com.algolia.search.apache.client;
+
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+
+import com.algolia.search.ApacheHttpRequester;
+import com.algolia.search.SearchClient;
+import com.algolia.search.SearchConfig;
+
+class TimeoutTest extends com.algolia.search.integration.client.TimeoutTest {
+  protected SearchConfig.Builder createBuilder() {
+    return new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+  }
+
+  protected SearchClient createClient(SearchConfig config) {
+    return new SearchClient(config, new ApacheHttpRequester(config));
+  }
+}

--- a/src/test/java/com/algolia/search/apache/index/BatchingTest.java
+++ b/src/test/java/com/algolia/search/apache/index/BatchingTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.index;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class BatchingTest extends com.algolia.search.integration.index.BatchingTest {
+  BatchingTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/index/IndexingTest.java
+++ b/src/test/java/com/algolia/search/apache/index/IndexingTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.index;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class IndexingTest extends com.algolia.search.integration.index.IndexingTest {
+  IndexingTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/index/QueryRulesTest.java
+++ b/src/test/java/com/algolia/search/apache/index/QueryRulesTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.index;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class QueryRulesTest extends com.algolia.search.integration.index.QueryRulesTest {
+  QueryRulesTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/index/ReplacingTest.java
+++ b/src/test/java/com/algolia/search/apache/index/ReplacingTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.index;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class ReplacingTest extends com.algolia.search.integration.index.ReplacingTest {
+  ReplacingTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/index/SearchTest.java
+++ b/src/test/java/com/algolia/search/apache/index/SearchTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.index;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SearchTest extends com.algolia.search.integration.index.SearchTest {
+  SearchTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/index/SettingsTest.java
+++ b/src/test/java/com/algolia/search/apache/index/SettingsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.index;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SettingsTest extends com.algolia.search.integration.index.SettingsTest {
+  SettingsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/index/SynonymsTest.java
+++ b/src/test/java/com/algolia/search/apache/index/SynonymsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.apache.index;
+
+import com.algolia.search.integration.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SynonymsTest extends com.algolia.search.integration.index.SynonymsTest {
+  SynonymsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/src/test/java/com/algolia/search/apache/insights/InsightsTest.java
+++ b/src/test/java/com/algolia/search/apache/insights/InsightsTest.java
@@ -1,0 +1,26 @@
+package com.algolia.search.apache.insights;
+
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+
+import com.algolia.search.InsightsClient;
+import com.algolia.search.integration.IntegrationTestExtension;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InsightsTest extends com.algolia.search.integration.insights.InsightsTest {
+  InsightsTest() {
+    super(
+        IntegrationTestExtension.searchClient,
+        new InsightsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1));
+  }
+
+  @AfterAll
+  void close() throws IOException {
+    insightsClient.close();
+  }
+}

--- a/src/test/java/com/algolia/search/apache/insights/InsightsTest.java
+++ b/src/test/java/com/algolia/search/apache/insights/InsightsTest.java
@@ -13,10 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith({IntegrationTestExtension.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InsightsTest extends com.algolia.search.integration.insights.InsightsTest {
+
+  private static InsightsClient insightsClient =
+      new InsightsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+
   InsightsTest() {
-    super(
-        IntegrationTestExtension.searchClient,
-        new InsightsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1));
+    super(IntegrationTestExtension.searchClient, insightsClient);
   }
 
   @AfterAll

--- a/src/test/java/com/algolia/search/integration/account/AccountCopyTest.java
+++ b/src/test/java/com/algolia/search/integration/account/AccountCopyTest.java
@@ -1,12 +1,12 @@
 package com.algolia.search.integration.account;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.algolia.search.AccountClient;
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.rules.*;
@@ -20,10 +20,16 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class AccountCopyTest {
+public abstract class AccountCopyTest {
+
+  private final SearchClient searchClient;
+  private final SearchClient searchClient2;
+
+  protected AccountCopyTest(SearchClient searchClient, SearchClient searchClient2) {
+    this.searchClient = searchClient;
+    this.searchClient2 = searchClient2;
+  }
 
   @Test
   void accountCopyIndexSameApp() {

--- a/src/test/java/com/algolia/search/integration/analytics/AnalyticsTest.java
+++ b/src/test/java/com/algolia/search/integration/analytics/AnalyticsTest.java
@@ -1,19 +1,19 @@
 package com.algolia.search.integration.analytics;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.IntegrationTestExtension.userName;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.algolia.search.AnalyticsClient;
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
 import com.algolia.search.exceptions.AlgoliaApiException;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.analytics.*;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.indexing.Query;
 import com.algolia.search.models.settings.IgnorePlurals;
-import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -25,23 +25,17 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
-@ExtendWith({IntegrationTestExtension.class})
-class AnalyticsTest {
+public abstract class AnalyticsTest {
 
-  private static AnalyticsClient analyticsClient;
+  protected final SearchClient searchClient;
+  protected final AnalyticsClient analyticsClient;
 
-  AnalyticsTest() {
-    analyticsClient = new AnalyticsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
-  }
-
-  @AfterAll
-  static void afterAll() throws IOException {
-    analyticsClient.close();
+  protected AnalyticsTest(SearchClient searchClient, AnalyticsClient analyticsClient) {
+    this.searchClient = searchClient;
+    this.analyticsClient = analyticsClient;
   }
 
   @Test

--- a/src/test/java/com/algolia/search/integration/client/ApiKeysTest.java
+++ b/src/test/java/com/algolia/search/integration/client/ApiKeysTest.java
@@ -1,18 +1,22 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.SearchClient;
 import com.algolia.search.models.apikeys.*;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class ApiKeysTest {
+public abstract class ApiKeysTest {
+
+  protected final SearchClient searchClient;
+
+  protected ApiKeysTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testApiKeys() {
 

--- a/src/test/java/com/algolia/search/integration/client/CopyIndexTest.java
+++ b/src/test/java/com/algolia/search/integration/client/CopyIndexTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.CopyIndexTestObject;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.indexing.CopyResponse;
@@ -19,10 +19,15 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class CopyIndexTest {
+public abstract class CopyIndexTest {
+
+  protected final SearchClient searchClient;
+
+  protected CopyIndexTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testCopyIndex() throws ExecutionException, InterruptedException {
     String sourceIndexName = getTestIndexName("source_index");

--- a/src/test/java/com/algolia/search/integration/client/LogsTest.java
+++ b/src/test/java/com/algolia/search/integration/client/LogsTest.java
@@ -1,18 +1,20 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.SearchClient;
 import com.algolia.search.models.indexing.IndicesResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class LogsTest {
+public abstract class LogsTest {
+  protected final SearchClient searchClient;
+
+  protected LogsTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
 
   @Test
   void testLog() throws ExecutionException, InterruptedException {

--- a/src/test/java/com/algolia/search/integration/client/MultiClusterManagementTest.java
+++ b/src/test/java/com/algolia/search/integration/client/MultiClusterManagementTest.java
@@ -1,14 +1,12 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getMcmUserId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;
 import com.algolia.search.exceptions.AlgoliaApiException;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.models.indexing.SearchResult;
 import com.algolia.search.models.mcm.*;
-import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -16,14 +14,17 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class MultiClusterManagementTest {
+public abstract class MultiClusterManagementTest {
+
+  protected final SearchClient mcmClient;
+
+  protected MultiClusterManagementTest(SearchClient mcmClient) {
+    this.mcmClient = mcmClient;
+  }
+
   @Test
-  void mcmTest() throws ExecutionException, InterruptedException, IOException {
-    SearchClient mcmClient = new SearchClient(ALGOLIA_APPLICATION_ID_MCM, ALGOLIA_ADMIN_KEY_MCM);
-
+  void mcmTest() throws ExecutionException, InterruptedException {
     ListClustersResponse listClusters = mcmClient.listClustersAsync().get();
     assertThat(listClusters.getClusters().size()).isEqualTo(2);
 
@@ -59,8 +60,6 @@ class MultiClusterManagementTest {
             .collect(Collectors.toList());
 
     userIDsToRemove.forEach(r -> mcmClient.removeUserID(r.getUserID()));
-
-    mcmClient.close();
   }
 
   void waitUserID(SearchClient client, String userID) throws InterruptedException {

--- a/src/test/java/com/algolia/search/integration/client/MultipleOperationsTest.java
+++ b/src/test/java/com/algolia/search/integration/client/MultipleOperationsTest.java
@@ -1,9 +1,9 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.SearchClient;
 import com.algolia.search.integration.models.AlgoliaMultipleOpObject;
 import com.algolia.search.models.indexing.*;
 import com.algolia.search.models.indexing.BatchOperation;
@@ -12,10 +12,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class MultipleOperationsTest {
+public abstract class MultipleOperationsTest {
+
+  protected final SearchClient searchClient;
+
+  protected MultipleOperationsTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testMultipleOperation() {
     String index1Name = getTestIndexName("multiple_operations");

--- a/src/test/java/com/algolia/search/integration/client/SecuredAPIKeyTest.java
+++ b/src/test/java/com/algolia/search/integration/client/SecuredAPIKeyTest.java
@@ -1,11 +1,10 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.apikeys.SecuredApiKeyRestriction;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
@@ -15,16 +14,24 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class SecuredAPIKeyTest {
+public abstract class SecuredAPIKeyTest {
+
+  protected SearchClient searchClient;
+
+  protected SecuredAPIKeyTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
+  protected abstract SearchClient createClientWithRestriction(SecuredApiKeyRestriction restriction)
+      throws Exception;
+
   @Test
   void testSecuredAPIKey() throws Exception {
     String index1Name = getTestIndexName("secured_api_keys");
     String index2Name = getTestIndexName("secured_api_keys_dev");
     SearchIndex<AlgoliaObject> index1 = searchClient.initIndex(index1Name, AlgoliaObject.class);
-    SearchIndex<AlgoliaObject> index2 = searchClient2.initIndex(index2Name, AlgoliaObject.class);
+    SearchIndex<AlgoliaObject> index2 = searchClient.initIndex(index2Name, AlgoliaObject.class);
     try {
       CompletableFuture<BatchIndexingResponse> addOneFuture =
           index1.saveObjectAsync(new AlgoliaObject().setObjectID("one"));
@@ -39,10 +46,7 @@ class SecuredAPIKeyTest {
       addOneFuture.get().waitTask();
       addTwoFuture.get().waitTask();
 
-      String key = searchClient.generateSecuredAPIKey(ALGOLIA_SEARCH_KEY_1, restriction);
-
-      try (SearchClient clientWithRestriction = new SearchClient(ALGOLIA_APPLICATION_ID_1, key)) {
-
+      try (SearchClient clientWithRestriction = createClientWithRestriction(restriction)) {
         SearchIndex<AlgoliaObject> index1WithoutRestriction =
             clientWithRestriction.initIndex(index1Name, AlgoliaObject.class);
         SearchIndex<AlgoliaObject> index2WithRestriction =

--- a/src/test/java/com/algolia/search/integration/client/TimeoutTest.java
+++ b/src/test/java/com/algolia/search/integration/client/TimeoutTest.java
@@ -1,7 +1,5 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_API_KEY_1;
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.algolia.search.SearchClient;
@@ -10,16 +8,16 @@ import com.algolia.search.exceptions.AlgoliaRetryException;
 import java.io.IOException;
 import org.junit.jupiter.api.Disabled;
 
-class TimeoutTest {
+public abstract class TimeoutTest {
+
+  protected abstract SearchConfig.Builder createBuilder();
+
+  protected abstract SearchClient createClient(SearchConfig config);
 
   @Disabled
   void testUnreachableHostExceptions() {
     try (SearchClient client =
-        new SearchClient(
-            new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1)
-                .setConnectTimeOut(2)
-                .setReadTimeOut(2)
-                .build())) {
+        createClient(createBuilder().setConnectTimeOut(2).setReadTimeOut(2).build())) {
       assertThatThrownBy(() -> client.getLogsAsync().get())
           .hasCauseInstanceOf(AlgoliaRetryException.class);
     } catch (IOException e) {

--- a/src/test/java/com/algolia/search/integration/index/BatchingTest.java
+++ b/src/test/java/com/algolia/search/integration/index/BatchingTest.java
@@ -1,10 +1,9 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.ObjectToBatch;
 import com.algolia.search.iterators.IndexIterable;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
@@ -18,11 +17,16 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
-@ExtendWith({IntegrationTestExtension.class})
-class BatchingTest {
+public abstract class BatchingTest {
+
+  protected final SearchClient searchClient;
+
+  protected BatchingTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testBatching() throws ExecutionException, InterruptedException {
     SearchIndex<ObjectToBatch> index =

--- a/src/test/java/com/algolia/search/integration/index/IndexingTest.java
+++ b/src/test/java/com/algolia/search/integration/index/IndexingTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.AlgoliaIndexingObject;
 import com.algolia.search.integration.models.DeleteByObject;
 import com.algolia.search.models.indexing.*;
@@ -14,10 +14,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class IndexingTest {
+public abstract class IndexingTest {
+
+  private final SearchClient searchClient;
+
+  protected IndexingTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testIndexingOperations() throws ExecutionException, InterruptedException {
     String indexName = getTestIndexName("indexing");

--- a/src/test/java/com/algolia/search/integration/index/QueryRulesTest.java
+++ b/src/test/java/com/algolia/search/integration/index/QueryRulesTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.iterators.RulesIterable;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.indexing.SearchResult;
@@ -19,11 +19,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
-@ExtendWith({IntegrationTestExtension.class})
-class QueryRulesTest {
+public abstract class QueryRulesTest {
+
+  protected final SearchClient searchClient;
+
+  protected QueryRulesTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void RulesTest() {
     SearchIndex<AlgoliaRule> index =

--- a/src/test/java/com/algolia/search/integration/index/ReplacingTest.java
+++ b/src/test/java/com/algolia/search/integration/index/ReplacingTest.java
@@ -1,12 +1,12 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
 import com.algolia.search.exceptions.AlgoliaApiException;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.indexing.MultiResponse;
@@ -19,10 +19,15 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class ReplacingTest {
+public abstract class ReplacingTest {
+
+  protected SearchClient searchClient;
+
+  protected ReplacingTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testReplacing() throws ExecutionException, InterruptedException {
     SearchIndex<AlgoliaObject> index =

--- a/src/test/java/com/algolia/search/integration/index/SearchTest.java
+++ b/src/test/java/com/algolia/search/integration/index/SearchTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.Employee;
 import com.algolia.search.models.indexing.*;
 import com.algolia.search.models.settings.IndexSettings;
@@ -15,10 +15,15 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class SearchTest {
+public abstract class SearchTest {
+
+  protected final SearchClient searchClient;
+
+  protected SearchTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testSearch() throws ExecutionException, InterruptedException {
     SearchIndex<Employee> index =

--- a/src/test/java/com/algolia/search/integration/index/SettingsTest.java
+++ b/src/test/java/com/algolia/search/integration/index/SettingsTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.settings.IndexSettings;
@@ -17,10 +17,15 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class SettingsTest {
+public abstract class SettingsTest {
+
+  protected SearchClient searchClient;
+
+  protected SettingsTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testSettings() throws ExecutionException, InterruptedException {
     String indexName = getTestIndexName("settings");

--- a/src/test/java/com/algolia/search/integration/index/SynonymsTest.java
+++ b/src/test/java/com/algolia/search/integration/index/SynonymsTest.java
@@ -1,29 +1,35 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
 import com.algolia.search.exceptions.AlgoliaApiException;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.indexing.SearchResult;
 import com.algolia.search.models.synonyms.SaveSynonymResponse;
 import com.algolia.search.models.synonyms.Synonym;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
-@ExtendWith({IntegrationTestExtension.class})
-class SynonymsTest {
+public abstract class SynonymsTest {
+
+  protected SearchClient searchClient;
+
+  protected SynonymsTest(SearchClient searchClient) {
+    this.searchClient = searchClient;
+  }
+
   @Test
   void testSynonyms() {
     String indexName = getTestIndexName("synonyms");

--- a/src/test/java/com/algolia/search/integration/insights/InsightsTest.java
+++ b/src/test/java/com/algolia/search/integration/insights/InsightsTest.java
@@ -3,77 +3,76 @@ package com.algolia.search.integration.insights;
 import static com.algolia.search.integration.IntegrationTestExtension.*;
 
 import com.algolia.search.InsightsClient;
+import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
 import com.algolia.search.UserInsightsClient;
-import com.algolia.search.integration.IntegrationTestExtension;
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.indexing.Query;
 import com.algolia.search.models.indexing.SearchResult;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({IntegrationTestExtension.class})
-class InsightsTest {
+public abstract class InsightsTest {
+  protected final SearchClient searchClient;
+  protected final InsightsClient insightsClient;
+
+  protected InsightsTest(SearchClient searchClient, InsightsClient insightsClient) {
+    this.searchClient = searchClient;
+    this.insightsClient = insightsClient;
+  }
+
   @Test
-  void testInsights() throws ExecutionException, InterruptedException, IOException {
+  void testInsights() throws ExecutionException, InterruptedException {
     String indexName = getTestIndexName("insights");
     SearchIndex<AlgoliaObject> index = searchClient.initIndex(indexName, AlgoliaObject.class);
 
-    try (InsightsClient insightsClient =
-        new InsightsClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1)) {
-      UserInsightsClient insights = insightsClient.user("test");
+    UserInsightsClient insights = insightsClient.user("test");
 
-      // Click
-      insights
-          .clickedFiltersAsync(
-              "clickedFilters", indexName, Collections.singletonList("brand:apple"))
-          .get();
-      insights
-          .clickedObjectIDsAsync("clickedObjectEvent", indexName, Arrays.asList("1", "2"))
-          .get();
+    // Click
+    insights
+        .clickedFiltersAsync("clickedFilters", indexName, Collections.singletonList("brand:apple"))
+        .get();
+    insights.clickedObjectIDsAsync("clickedObjectEvent", indexName, Arrays.asList("1", "2")).get();
 
-      // Conversions
-      insights
-          .convertedObjectIDsAsync("convertedObjectIDs", indexName, Arrays.asList("1", "2"))
-          .get();
-      insights
-          .convertedFiltersAsync(
-              "converterdFilters", indexName, Collections.singletonList("brand:apple"))
-          .get();
+    // Conversions
+    insights
+        .convertedObjectIDsAsync("convertedObjectIDs", indexName, Arrays.asList("1", "2"))
+        .get();
+    insights
+        .convertedFiltersAsync(
+            "converterdFilters", indexName, Collections.singletonList("brand:apple"))
+        .get();
 
-      // View
-      insights
-          .viewedFiltersAsync(
-              "viewedFilters", indexName, Arrays.asList("brand:apple", "brand:google"))
-          .get();
-      insights.viewedObjectIDsAsync("viewedObjectIDs", indexName, Arrays.asList("1", "2")).get();
+    // View
+    insights
+        .viewedFiltersAsync(
+            "viewedFilters", indexName, Arrays.asList("brand:apple", "brand:google"))
+        .get();
+    insights.viewedObjectIDsAsync("viewedObjectIDs", indexName, Arrays.asList("1", "2")).get();
 
-      index.saveObjectAsync(new AlgoliaObject().setObjectID("one")).get().waitTask();
+    index.saveObjectAsync(new AlgoliaObject().setObjectID("one")).get().waitTask();
 
-      Query query = new Query().setEnablePersonalization(true).setClickAnalytics(true);
+    Query query = new Query().setEnablePersonalization(true).setClickAnalytics(true);
 
-      SearchResult<AlgoliaObject> search1 = index.searchAsync(query).get();
-      insights
-          .clickedObjectIDsAfterSearchAsync(
-              "clickedObjectIDsAfterSearch",
-              indexName,
-              Arrays.asList("1", "2"),
-              Arrays.asList(17L, 19L),
-              search1.getQueryID())
-          .get();
+    SearchResult<AlgoliaObject> search1 = index.searchAsync(query).get();
+    insights
+        .clickedObjectIDsAfterSearchAsync(
+            "clickedObjectIDsAfterSearch",
+            indexName,
+            Arrays.asList("1", "2"),
+            Arrays.asList(17L, 19L),
+            search1.getQueryID())
+        .get();
 
-      SearchResult<AlgoliaObject> search2 = index.searchAsync(query).get();
-      insights
-          .convertedObjectIDsAfterSearchAsync(
-              "convertedObjectIDsAfterSearch",
-              indexName,
-              Arrays.asList("1", "2"),
-              search2.getQueryID())
-          .get();
-    }
+    SearchResult<AlgoliaObject> search2 = index.searchAsync(query).get();
+    insights
+        .convertedObjectIDsAfterSearchAsync(
+            "convertedObjectIDsAfterSearch",
+            indexName,
+            Arrays.asList("1", "2"),
+            search2.getQueryID())
+        .get();
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | none
| Need Doc update   | no

## Describe your change

Extract clients from test scenarios - injecting the former in the latter

## What problem is this fixing?

This makes injection of custom clients possible - so that the test suite can be reused for custom clients.