### PR TITLE
test: Detach "core" from "apache"

### DIFF
--- a/src/test/java/com/algolia/search/apache/IntegrationTestExtension.java
+++ b/src/test/java/com/algolia/search/apache/IntegrationTestExtension.java
@@ -1,4 +1,4 @@
-package com.algolia.search.integration;
+package com.algolia.search.apache;
 
 import com.algolia.search.SearchClient;
 import com.algolia.search.models.indexing.ActionEnum;

--- a/src/test/java/com/algolia/search/apache/account/AccountCopyTest.java
+++ b/src/test/java/com/algolia/search/apache/account/AccountCopyTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.account;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/analytics/AnalyticsTest.java
+++ b/src/test/java/com/algolia/search/apache/analytics/AnalyticsTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.apache.analytics;
 
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_API_KEY_1;
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_API_KEY_1;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.AnalyticsClient;
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/algolia/search/apache/client/ApiKeysTest.java
+++ b/src/test/java/com/algolia/search/apache/client/ApiKeysTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.client;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/client/CopyIndexTest.java
+++ b/src/test/java/com/algolia/search/apache/client/CopyIndexTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.client;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/client/LogsTest.java
+++ b/src/test/java/com/algolia/search/apache/client/LogsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.client;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/client/MultiClusterManagementTest.java
+++ b/src/test/java/com/algolia/search/apache/client/MultiClusterManagementTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.apache.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_ADMIN_KEY_MCM;
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_MCM;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_ADMIN_KEY_MCM;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_MCM;
 
 import com.algolia.search.SearchClient;
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;

--- a/src/test/java/com/algolia/search/apache/client/MultipleOperationsTest.java
+++ b/src/test/java/com/algolia/search/apache/client/MultipleOperationsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.client;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/client/SecuredAPIKeyTest.java
+++ b/src/test/java/com/algolia/search/apache/client/SecuredAPIKeyTest.java
@@ -1,9 +1,9 @@
 package com.algolia.search.apache.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
+import static com.algolia.search.apache.IntegrationTestExtension.*;
 
 import com.algolia.search.SearchClient;
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import com.algolia.search.models.apikeys.SecuredApiKeyRestriction;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/src/test/java/com/algolia/search/apache/client/TimeoutTest.java
+++ b/src/test/java/com/algolia/search/apache/client/TimeoutTest.java
@@ -1,7 +1,7 @@
 package com.algolia.search.apache.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_API_KEY_1;
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_API_KEY_1;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.ApacheHttpRequester;
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/apache/index/BatchingTest.java
+++ b/src/test/java/com/algolia/search/apache/index/BatchingTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.index;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/index/IndexingTest.java
+++ b/src/test/java/com/algolia/search/apache/index/IndexingTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.index;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/index/QueryRulesTest.java
+++ b/src/test/java/com/algolia/search/apache/index/QueryRulesTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.index;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/index/ReplacingTest.java
+++ b/src/test/java/com/algolia/search/apache/index/ReplacingTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.index;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/index/SearchTest.java
+++ b/src/test/java/com/algolia/search/apache/index/SearchTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.index;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/index/SettingsTest.java
+++ b/src/test/java/com/algolia/search/apache/index/SettingsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.index;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/index/SynonymsTest.java
+++ b/src/test/java/com/algolia/search/apache/index/SynonymsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.apache.index;
 
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({IntegrationTestExtension.class})

--- a/src/test/java/com/algolia/search/apache/insights/InsightsTest.java
+++ b/src/test/java/com/algolia/search/apache/insights/InsightsTest.java
@@ -1,10 +1,10 @@
 package com.algolia.search.apache.insights;
 
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_API_KEY_1;
-import static com.algolia.search.integration.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_API_KEY_1;
+import static com.algolia.search.apache.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.InsightsClient;
-import com.algolia.search.integration.IntegrationTestExtension;
+import com.algolia.search.apache.IntegrationTestExtension;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;

--- a/src/test/java/com/algolia/search/integration/IntegrationTestExtension.java
+++ b/src/test/java/com/algolia/search/integration/IntegrationTestExtension.java
@@ -7,8 +7,6 @@ import com.algolia.search.models.indexing.IndicesResponse;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -28,10 +26,6 @@ public class IntegrationTestExtension
   public static String ALGOLIA_APPLICATION_ID_MCM = System.getenv("ALGOLIA_APPLICATION_ID_MCM");
   public static String ALGOLIA_ADMIN_KEY_MCM = System.getenv("ALGOLIA_ADMIN_KEY_MCM");
 
-  private static String osName = System.getProperty("os.name").trim();
-  public static String userName = System.getProperty("user.name");
-  private static String javaVersion = System.getProperty("java.version");
-
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
     checkEnvironmentVariable();
@@ -47,17 +41,6 @@ public class IntegrationTestExtension
       searchClient.close();
     } catch (IOException ignored) {
     }
-  }
-
-  public static String getTestIndexName(String indexName) {
-    ZonedDateTime utc = ZonedDateTime.now(ZoneOffset.UTC);
-    return String.format("java_jvm_%s_%s_%s_%s_%s", javaVersion, utc, osName, userName, indexName);
-  }
-
-  public static String getMcmUserId() {
-    ZonedDateTime utc = ZonedDateTime.now(ZoneOffset.UTC);
-    return String.format(
-        "java-%s-%s", DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss").format(utc), userName);
   }
 
   private void cleanPreviousIndices() {

--- a/src/test/java/com/algolia/search/integration/TestHelpers.java
+++ b/src/test/java/com/algolia/search/integration/TestHelpers.java
@@ -1,0 +1,22 @@
+package com.algolia.search.integration;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TestHelpers {
+  public static String userName = System.getProperty("user.name");
+  private static String osName = System.getProperty("os.name").trim();
+  private static String javaVersion = System.getProperty("java.version");
+
+  public static String getTestIndexName(String indexName) {
+    ZonedDateTime utc = ZonedDateTime.now(ZoneOffset.UTC);
+    return String.format("java_jvm_%s_%s_%s_%s_%s", javaVersion, utc, osName, userName, indexName);
+  }
+
+  public static String getMcmUserId() {
+    ZonedDateTime utc = ZonedDateTime.now(ZoneOffset.UTC);
+    return String.format(
+        "java-%s-%s", DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss").format(utc), userName);
+  }
+}

--- a/src/test/java/com/algolia/search/integration/account/AccountCopyTest.java
+++ b/src/test/java/com/algolia/search/integration/account/AccountCopyTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.account;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/src/test/java/com/algolia/search/integration/analytics/AnalyticsTest.java
+++ b/src/test/java/com/algolia/search/integration/analytics/AnalyticsTest.java
@@ -1,7 +1,7 @@
 package com.algolia.search.integration.analytics;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
-import static com.algolia.search.integration.IntegrationTestExtension.userName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.userName;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 

--- a/src/test/java/com/algolia/search/integration/client/CopyIndexTest.java
+++ b/src/test/java/com/algolia/search/integration/client/CopyIndexTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/client/MultiClusterManagementTest.java
+++ b/src/test/java/com/algolia/search/integration/client/MultiClusterManagementTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getMcmUserId;
+import static com.algolia.search.integration.TestHelpers.getMcmUserId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/client/MultipleOperationsTest.java
+++ b/src/test/java/com/algolia/search/integration/client/MultipleOperationsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/client/SecuredAPIKeyTest.java
+++ b/src/test/java/com/algolia/search/integration/client/SecuredAPIKeyTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.client;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/index/IndexingTest.java
+++ b/src/test/java/com/algolia/search/integration/index/IndexingTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/index/QueryRulesTest.java
+++ b/src/test/java/com/algolia/search/integration/index/QueryRulesTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/index/ReplacingTest.java
+++ b/src/test/java/com/algolia/search/integration/index/ReplacingTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 

--- a/src/test/java/com/algolia/search/integration/index/SearchTest.java
+++ b/src/test/java/com/algolia/search/integration/index/SearchTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/index/SettingsTest.java
+++ b/src/test/java/com/algolia/search/integration/index/SettingsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.integration.index;
 
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.algolia.search.SearchClient;

--- a/src/test/java/com/algolia/search/integration/index/SynonymsTest.java
+++ b/src/test/java/com/algolia/search/integration/index/SynonymsTest.java
@@ -1,5 +1,9 @@
 package com.algolia.search.integration.index;
 
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
 import com.algolia.search.exceptions.AlgoliaApiException;
@@ -9,17 +13,12 @@ import com.algolia.search.models.synonyms.SaveSynonymResponse;
 import com.algolia.search.models.synonyms.Synonym;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
-import static com.algolia.search.integration.IntegrationTestExtension.getTestIndexName;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public abstract class SynonymsTest {

--- a/src/test/java/com/algolia/search/integration/insights/InsightsTest.java
+++ b/src/test/java/com/algolia/search/integration/insights/InsightsTest.java
@@ -1,11 +1,10 @@
 package com.algolia.search.integration.insights;
 
-import static com.algolia.search.integration.IntegrationTestExtension.*;
-
 import com.algolia.search.InsightsClient;
 import com.algolia.search.SearchClient;
 import com.algolia.search.SearchIndex;
 import com.algolia.search.UserInsightsClient;
+import com.algolia.search.integration.TestHelpers;
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.indexing.Query;
 import com.algolia.search.models.indexing.SearchResult;
@@ -25,7 +24,7 @@ public abstract class InsightsTest {
 
   @Test
   void testInsights() throws ExecutionException, InterruptedException {
-    String indexName = getTestIndexName("insights");
+    String indexName = TestHelpers.getTestIndexName("insights");
     SearchIndex<AlgoliaObject> index = searchClient.initIndex(indexName, AlgoliaObject.class);
 
     UserInsightsClient insights = insightsClient.user("test");


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          |no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | none
| Need Doc update   | no


## Describe your change

Move the setup of the Apache-based search client away from the package containing the actual test suite.

## What problem is this fixing?

This actually extracts the last remaining dependency on the Apache client from the tests suite.