### PR TITLE
packaging: Generate uber jars for -core and -apache

### DIFF
--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>algoliasearch</artifactId>
+        <groupId>com.algolia</groupId>
+        <version>3.0.0-beta-1</version>
+    </parent>
+    <artifactId>algoliasearch-apache-uber</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.algolia</groupId>
+            <artifactId>algoliasearch-apache</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters combine.children="append">
+                                <filter>
+                                    <artifact>org.apache.*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>commons-codec:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>commons-logging:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations combine.children="append">
+                                <relocation>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>com.algolia.search.org.apache</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/algoliasearch-core-uber/pom.xml
+++ b/algoliasearch-core-uber/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>algoliasearch</artifactId>
+        <groupId>com.algolia</groupId>
+        <version>3.0.0-beta-1</version>
+    </parent>
+    <artifactId>algoliasearch-core-uber</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.algolia</groupId>
+            <artifactId>algoliasearch-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,9 @@
 
     <modules>
         <module>algoliasearch-core</module>
+        <module>algoliasearch-core-uber</module>
         <module>algoliasearch-apache</module>
+        <module>algoliasearch-apache-uber</module>
     </modules>
 
     <licenses>
@@ -178,5 +180,58 @@
             </dependencies>
         </profile>
     </profiles>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.1</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                            <configuration>
+                                <shadedClassifierName>uber</shadedClassifierName>
+                                <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                                <artifactSet>
+                                    <excludes>
+                                        <exclude>org.slf4j:slf4j-api</exclude>
+                                    </excludes>
+                                </artifactSet>
+                                <filters>
+                                    <filter>
+                                        <artifact>*:*</artifact>
+                                        <excludes>
+                                            <exclude>META-INF/maven/**</exclude>
+                                            <exclude>META-INF/services/**</exclude>
+                                        </excludes>
+                                    </filter>
+                                    <filter>
+                                        <artifact>com.fasterxml.*:*</artifact>
+                                        <excludes>
+                                            <exclude>META-INF/**</exclude>
+                                        </excludes>
+                                    </filter>
+                                </filters>
+                                <relocations>
+                                    <relocation>
+                                        <pattern>com.fasterxml.jackson</pattern>
+                                        <shadedPattern>com.algolia.search.com.fasterxml.jackson</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>javax.annotation</pattern>
+                                        <shadedPattern>com.algolia.search.javax.annotation</shadedPattern>
+                                    </relocation>
+                                </relocations>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>


### PR DESCRIPTION
Relocating embedded dependencies inside com.algoliasearch, filtering
out unused resources.

Note that slf4j-api is NOT embedded in the uber jars, on purpose: if
slf4j-api is embedded here, it would need to be relocated (*), yet if
gets relocated, implementations cannot be injected anymore (**),
making slf4j irrelevant.

(*) Embedding jars in an uber-library _require_ their relocation: a
library is meant to be used along with other jars, which may depend on
other versions of the jars embedded here. Relocating these mostly get
rid of conflicts; not relocating them, would on the contrary make
conflicts practically impossible to solve.

(**) the injection used by slf4j is namespace based; if the api gets
relocated, implementation would have to be relocated too.

From a "pom.xml point of view", a pluginManagement section is set in
the root pom.xml to configure the shading - but not apply it. This
configuration in then leveraged in dedicated modules
(algolia-core-uber and algolia-apache-uber) coming with their own
pom.xml files (and possibly adjusting - augmenting - the relocations,
in the apache flavor).