### PR TITLE
Make some query rule and synonym management APIs more consistent with established conventions

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/SyncRules.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/SyncRules.java
@@ -123,6 +123,17 @@ public interface SyncRules<T> extends SyncBaseIndex<T> {
    *
    * @param ruleId the id of the query rule
    * @param forwardToReplicas should this request be forwarded to replicas
+   * @return the associated task
+   */
+  default Task deleteRule(@Nonnull String ruleId, boolean forwardToReplicas) throws AlgoliaException {
+    return getApiClient().deleteRule(getName(), ruleId, forwardToReplicas, new RequestOptions());
+  }
+
+  /**
+   * Deletes a query rule
+   *
+   * @param ruleId the id of the query rule
+   * @param forwardToReplicas should this request be forwarded to replicas
    * @param requestOptions Options to pass to this request
    * @return the associated task
    */

--- a/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/Consequence.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/Consequence.java
@@ -1,6 +1,5 @@
 package com.algolia.search.inputs.query_rules;
 
-import com.algolia.search.objects.Hide;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.io.Serializable;
 import java.util.List;
@@ -46,7 +45,8 @@ public class Consequence implements Serializable {
     return hide;
   }
 
-  public void setHide(List<Hide> hide) {
+  public Consequence setHide(List<Hide> hide) {
     this.hide = hide;
+    return this;
   }
 }

--- a/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/Hide.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/inputs/query_rules/Hide.java
@@ -1,4 +1,4 @@
-package com.algolia.search.objects;
+package com.algolia.search.inputs.query_rules;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -17,7 +17,8 @@ public class Hide {
     return objectID;
   }
 
-  public void setObjectID(String objectID) {
+  public Hide setObjectID(String objectID) {
     this.objectID = objectID;
+    return this;
   }
 }

--- a/algoliasearch-common/src/main/java/com/algolia/search/objects/QueryBase.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/objects/QueryBase.java
@@ -326,7 +326,7 @@ public abstract class QueryBase<T extends QueryBase<?>> implements Serializable 
   }
 
   @JsonAnySetter
-  public T addCustomParameter(String key, String value) {
+  public T addCustomParameter(String key, Object value) {
     this.customParameters.put(key, value);
     return (T) this;
   }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change
While integrating with Algolia, a couple SDK interactions seemed to not follow conventions found in other places in the existing SDK.  Namely the usage of fluent setters (that return `this`).  

Additionally deleteRule and deleteSynonym didn't have symmetry in their method signatures. 

## What problem is this fixing?
SDK consistency