### PR TITLE
adds: GZip compression feature (#591)

### DIFF
--- a/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
@@ -1,5 +1,6 @@
 package com.algolia.search;
 
+import com.algolia.search.models.common.CompressionType;
 import com.algolia.search.models.indexing.ActionEnum;
 import com.algolia.search.models.indexing.BatchOperation;
 import com.algolia.search.models.indexing.IndicesResponse;
@@ -29,7 +30,12 @@ public class IntegrationTestExtension
   public void beforeAll(ExtensionContext context) throws Exception {
     checkEnvironmentVariable();
     searchClient = DefaultSearchClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
-    searchClient2 = DefaultSearchClient.create(ALGOLIA_APPLICATION_ID_2, ALGOLIA_API_KEY_2);
+    // Disabling gzip for client2 because GZip not is not enabled yet on the server
+    SearchConfig client2Config =
+        new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_2, ALGOLIA_API_KEY_2)
+            .setCompressionType(CompressionType.NONE)
+            .build();
+    searchClient2 = DefaultSearchClient.create(client2Config);
     cleanPreviousIndices();
   }
 

--- a/algoliasearch-core/src/main/java/com/algolia/search/AnalyticsConfig.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/AnalyticsConfig.java
@@ -1,6 +1,7 @@
 package com.algolia.search;
 
 import com.algolia.search.models.common.CallType;
+import com.algolia.search.models.common.CompressionType;
 import java.util.*;
 import javax.annotation.Nonnull;
 
@@ -16,7 +17,7 @@ public final class AnalyticsConfig extends ConfigBase {
      * @param apiKey The API Key
      */
     public Builder(@Nonnull String applicationID, @Nonnull String apiKey) {
-      super(applicationID, apiKey, createDefaultHosts());
+      super(applicationID, apiKey, createDefaultHosts(), CompressionType.NONE);
     }
 
     @Override

--- a/algoliasearch-core/src/main/java/com/algolia/search/ConfigBase.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/ConfigBase.java
@@ -1,5 +1,6 @@
 package com.algolia.search;
 
+import com.algolia.search.models.common.CompressionType;
 import com.algolia.search.util.AlgoliaUtils;
 import java.util.HashMap;
 import java.util.List;
@@ -23,6 +24,7 @@ public abstract class ConfigBase {
   private final Integer connectTimeOut;
   private final List<StatefulHost> hosts;
   private final ExecutorService executor;
+  private final CompressionType compressionType;
 
   /** Config base builder to ensure the immutability of the configuration. */
   public abstract static class Builder<T extends Builder<T>> {
@@ -36,6 +38,7 @@ public abstract class ConfigBase {
     private Integer connectTimeOut;
     private List<StatefulHost> hosts;
     private ExecutorService executor;
+    protected CompressionType compressionType;
 
     /**
      * Builds a base configuration
@@ -48,13 +51,16 @@ public abstract class ConfigBase {
     public Builder(
         @Nonnull String applicationID,
         @Nonnull String apiKey,
-        @Nonnull List<StatefulHost> defaultHosts) {
+        @Nonnull List<StatefulHost> defaultHosts,
+        @Nonnull CompressionType compressionType) {
+
       this.applicationID = applicationID;
       this.apiKey = apiKey;
 
       this.batchSize = 1000;
       this.hosts = defaultHosts;
       this.connectTimeOut = Defaults.CONNECT_TIMEOUT_MS;
+      this.compressionType = compressionType;
 
       this.defaultHeaders = new HashMap<>();
       this.defaultHeaders.put(Defaults.ALGOLIA_APPLICATION_HEADER, applicationID);
@@ -145,6 +151,7 @@ public abstract class ConfigBase {
     this.applicationID = builder.applicationID;
     this.defaultHeaders = builder.defaultHeaders;
     this.batchSize = builder.batchSize;
+    this.compressionType = builder.compressionType;
     this.readTimeOut = builder.readTimeOut;
     this.writeTimeOut = builder.writeTimeOut;
     this.connectTimeOut = builder.connectTimeOut;
@@ -166,6 +173,10 @@ public abstract class ConfigBase {
 
   public int getBatchSize() {
     return batchSize;
+  }
+
+  public CompressionType getCompressionType() {
+    return compressionType;
   }
 
   public Integer getReadTimeOut() {

--- a/algoliasearch-core/src/main/java/com/algolia/search/InsightsConfig.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/InsightsConfig.java
@@ -1,6 +1,7 @@
 package com.algolia.search;
 
 import com.algolia.search.models.common.CallType;
+import com.algolia.search.models.common.CompressionType;
 import com.algolia.search.util.AlgoliaUtils;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -29,7 +30,7 @@ public final class InsightsConfig extends ConfigBase {
      * @param apiKey The API Key
      */
     public Builder(@Nonnull String applicationID, @Nonnull String apiKey, @Nonnull String region) {
-      super(applicationID, apiKey, createDefaultHosts(region));
+      super(applicationID, apiKey, createDefaultHosts(region), CompressionType.NONE);
     }
 
     @Override

--- a/algoliasearch-core/src/main/java/com/algolia/search/SearchConfig.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/SearchConfig.java
@@ -1,6 +1,7 @@
 package com.algolia.search;
 
 import com.algolia.search.models.common.CallType;
+import com.algolia.search.models.common.CompressionType;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -13,7 +14,7 @@ public final class SearchConfig extends ConfigBase {
 
     /** Builds a {@link SearchConfig} with the default hosts */
     public Builder(@Nonnull String applicationID, @Nonnull String apiKey) {
-      super(applicationID, apiKey, createDefaultHosts(applicationID));
+      super(applicationID, apiKey, createDefaultHosts(applicationID), CompressionType.GZIP);
     }
 
     @Override
@@ -50,6 +51,12 @@ public final class SearchConfig extends ConfigBase {
       Collections.shuffle(commonHosts, new Random());
 
       return Stream.concat(hosts.stream(), commonHosts.stream()).collect(Collectors.toList());
+    }
+
+    /** Enables compression for the SearchClient. See {@link CompressionType} */
+    public Builder setCompressionType(@Nonnull CompressionType compressionType) {
+      this.compressionType = compressionType;
+      return this;
     }
   }
 

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/HttpRequest.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/HttpRequest.java
@@ -1,11 +1,22 @@
 package com.algolia.search.models;
 
+import com.algolia.search.models.common.CompressionType;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
 public class HttpRequest {
+
+  public HttpRequest(
+      HttpMethod method,
+      String methodPath,
+      Map<String, String> headers,
+      int timeout,
+      CompressionType compressionType) {
+    this(method, methodPath, headers, timeout);
+    this.compressionType = compressionType;
+  }
 
   public HttpRequest(
       HttpMethod method, String methodPath, Map<String, String> headers, int timeout) {
@@ -69,6 +80,31 @@ public class HttpRequest {
     return this;
   }
 
+  public CompressionType getCompressionType() {
+    return compressionType;
+  }
+
+  public HttpRequest setCompressionType(CompressionType compressionType) {
+    this.compressionType = compressionType;
+    return this;
+  }
+
+  /**
+   * Tells if any compression can be enabled for a request or not. Compression is enabled only for
+   * POST/PUT methods on the Search API (not on Analytics and Insights).
+   */
+  public boolean canCompress() {
+    if (this.compressionType == null || this.method == null) {
+      return false;
+    }
+
+    boolean isMethodValid =
+        this.method.equals(HttpMethod.POST) || this.method.equals(HttpMethod.PUT);
+    boolean isCompressionEnabled = this.compressionType.equals(CompressionType.GZIP);
+
+    return isMethodValid && isCompressionEnabled;
+  }
+
   public void incrementTimeout(int retryCount) {
     this.timeout *= (retryCount + 1);
   }
@@ -79,4 +115,5 @@ public class HttpRequest {
   private Map<String, String> headers;
   private InputStream body;
   private int timeout;
+  private CompressionType compressionType;
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/CompressionType.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/CompressionType.java
@@ -1,0 +1,6 @@
+package com.algolia.search.models.common;
+
+public enum CompressionType {
+  NONE,
+  GZIP
+}


### PR DESCRIPTION
Adds the possibility to compress request for SearchClient.
For the moment only GZIP compression is available.
GZIP compression is enabled by default for SearchClient.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #591 
| Need Doc update   | yes


`AccountClient` test is expected to fail because the feature is not enabled on the second test server yet.
