### PR TITLE
fixed(synonym): handle deserialization of lowercase variant of synonym types

### DIFF
--- a/algoliasearch-common/src/main/java/com/algolia/search/inputs/synonym/AbstractSynonym.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/inputs/synonym/AbstractSynonym.java
@@ -11,8 +11,11 @@ import java.io.Serializable;
 )
 @JsonSubTypes({
   @JsonSubTypes.Type(value = AltCorrection1.class, name = SynonymType.ALT_CORRECTION_1),
+  @JsonSubTypes.Type(value = AltCorrection1.class, name = SynonymTypeLowerCase.ALT_CORRECTION_1),
   @JsonSubTypes.Type(value = AltCorrection2.class, name = SynonymType.ALT_CORRECTION_2),
+  @JsonSubTypes.Type(value = AltCorrection2.class, name = SynonymTypeLowerCase.ALT_CORRECTION_2),
   @JsonSubTypes.Type(value = OneWaySynonym.class, name = SynonymType.ONE_WAY_SYNONYM),
+  @JsonSubTypes.Type(value = OneWaySynonym.class, name = SynonymTypeLowerCase.ONE_WAY_SYNONYM),
   @JsonSubTypes.Type(value = Placeholder.class, name = SynonymType.PLACEHOLDER),
   @JsonSubTypes.Type(value = Synonym.class, name = SynonymType.SYNONYM),
 })

--- a/algoliasearch-common/src/main/java/com/algolia/search/inputs/synonym/SynonymType.java
+++ b/algoliasearch-common/src/main/java/com/algolia/search/inputs/synonym/SynonymType.java
@@ -1,10 +1,15 @@
 package com.algolia.search.inputs.synonym;
 
 interface SynonymType {
-
   String ALT_CORRECTION_1 = "altCorrection1";
   String ALT_CORRECTION_2 = "altCorrection2";
   String ONE_WAY_SYNONYM = "oneWaySynonym";
   String PLACEHOLDER = "placeholder";
   String SYNONYM = "synonym";
+}
+
+interface SynonymTypeLowerCase {
+  static String ALT_CORRECTION_1 = "altcorrection1";
+  static String ALT_CORRECTION_2 = "altcorrection2";
+  static String ONE_WAY_SYNONYM = "onewaysynonym";
 }

--- a/algoliasearch-tests/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-tests/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -27,13 +27,31 @@ public class JacksonParserTest {
 
     synonym =
         DEFAULT_OBJECT_MAPPER.readValue(
+            "{\"type\":\"altcorrection1\",\"objectID\":\"synonymID\",\"corrections\":[\"1\", \"2\"],\"word\":\"word\"}",
+            AbstractSynonym.class);
+    assertThat(synonym).isInstanceOf(AltCorrection1.class);
+
+    synonym =
+        DEFAULT_OBJECT_MAPPER.readValue(
             "{\"type\":\"altCorrection2\",\"objectID\":\"synonymID\",\"corrections\":[\"1\", \"2\"],\"word\":\"word\"}",
             AbstractSynonym.class);
     assertThat(synonym).isInstanceOf(AltCorrection2.class);
 
     synonym =
         DEFAULT_OBJECT_MAPPER.readValue(
+            "{\"type\":\"altcorrection2\",\"objectID\":\"synonymID\",\"corrections\":[\"1\", \"2\"],\"word\":\"word\"}",
+            AbstractSynonym.class);
+    assertThat(synonym).isInstanceOf(AltCorrection2.class);
+
+    synonym =
+        DEFAULT_OBJECT_MAPPER.readValue(
             "{\"type\":\"oneWaySynonym\",\"objectID\":\"synonymID\",\"synonyms\":[\"1\", \"2\"],\"input\":\"input\"}",
+            AbstractSynonym.class);
+    assertThat(synonym).isInstanceOf(OneWaySynonym.class);
+
+    synonym =
+        DEFAULT_OBJECT_MAPPER.readValue(
+            "{\"type\":\"onewaysynonym\",\"objectID\":\"synonymID\",\"synonyms\":[\"1\", \"2\"],\"input\":\"input\"}",
             AbstractSynonym.class);
     assertThat(synonym).isInstanceOf(OneWaySynonym.class);
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #597 
| Need Doc update   | no


## Describe your change

    This commit adds new package-private interface to list all lowercase
    variants of the synonym types and use them as JsonSubTypes annotations
    of the AbstractSynonym class.

    Note that we considered using ACCEPT_CASE_INSENSITIVE_PROPERTIES
    MapperFeature from jackson-databind but this needs to be set globally at
    the ObjectMapper's level, which we do not want.

## What problem is this fixing?

    Synonyms saved through the Algolia dashboard see their types stored as
    lowercase. Jackson not being able to deserialize lowercase enums and
    keys into their upper-case or mixed-case counterparts, retrieving
    synonyms that were saved from the dashboard made implementations crash.