### PR TITLE
fix: default compression for SearchClient

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/SearchConfig.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/SearchConfig.java
@@ -14,7 +14,7 @@ public final class SearchConfig extends ConfigBase {
 
     /** Builds a {@link SearchConfig} with the default hosts */
     public Builder(@Nonnull String applicationID, @Nonnull String apiKey) {
-      super(applicationID, apiKey, createDefaultHosts(applicationID), CompressionType.GZIP);
+      super(applicationID, apiKey, createDefaultHosts(applicationID), CompressionType.NONE);
     }
 
     @Override


### PR DESCRIPTION
Set default compression to `None` instead of `GZIP`
