### PR TITLE
fix: missing catch clauses in the httpRequester

### DIFF
--- a/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
+++ b/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
@@ -12,15 +12,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
-import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.HttpEntity;
+import org.apache.http.*;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.DeflateDecompressingEntity;
 import org.apache.http.client.entity.GzipDecompressingEntity;
 import org.apache.http.client.methods.*;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
@@ -68,8 +67,12 @@ final class ApacheHttpRequester implements HttpRequester {
               if (t.getCause() instanceof ConnectTimeoutException
                   || t.getCause() instanceof SocketTimeoutException
                   || t.getCause() instanceof ConnectException
-                  || t.getCause() instanceof TimeoutException) {
+                  || t.getCause() instanceof TimeoutException
+                  || t.getCause() instanceof ConnectionPoolTimeoutException
+                  || t.getCause() instanceof NoHttpResponseException) {
                 return new HttpResponse(true);
+              } else if (t.getCause() instanceof HttpException) {
+                return new HttpResponse().setNetworkError(true);
               }
               throw new AlgoliaRuntimeException(t);
             });

--- a/algoliasearch-core/src/main/java/com/algolia/search/HttpTransport.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/HttpTransport.java
@@ -163,8 +163,7 @@ class HttpTransport {
         .performRequestAsync(request)
         .thenComposeAsync(
             resp -> {
-              switch (retryStrategy.decide(
-                  currentHost, resp.getHttpStatusCode(), resp.isTimedOut())) {
+              switch (retryStrategy.decide(currentHost, resp)) {
                 case SUCCESS:
                   try (InputStream dataStream = resp.getBody()) {
                     TResult result = Defaults.getObjectMapper().readValue(dataStream, type);

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/HttpResponse.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/HttpResponse.java
@@ -4,6 +4,8 @@ import java.io.InputStream;
 
 public class HttpResponse {
 
+  public HttpResponse() {}
+
   public HttpResponse(int httpStatusCode, InputStream body) {
     this.httpStatusCode = httpStatusCode;
     this.body = body;
@@ -54,8 +56,18 @@ public class HttpResponse {
     return this;
   }
 
+  public boolean isNetworkError() {
+    return isNetworkError;
+  }
+
+  public HttpResponse setNetworkError(boolean networkError) {
+    isNetworkError = networkError;
+    return this;
+  }
+
   private int httpStatusCode;
   private InputStream body;
   private String error;
   private boolean isTimedOut;
+  private boolean isNetworkError;
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/util/HttpStatusCodeUtils.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/util/HttpStatusCodeUtils.java
@@ -1,6 +1,12 @@
 package com.algolia.search.util;
 
+import com.algolia.search.models.HttpResponse;
+
 public class HttpStatusCodeUtils {
+
+  public static boolean isSuccess(HttpResponse response) {
+    return isSuccess(response.getHttpStatusCode());
+  }
 
   public static boolean isSuccess(int httpStatusCode) {
     return httpStatusCode / 100 == 2;

--- a/algoliasearch-core/src/test/java/com/algolia/search/RetryStrategyTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/RetryStrategyTest.java
@@ -2,6 +2,7 @@ package com.algolia.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.models.HttpResponse;
 import com.algolia.search.models.common.CallType;
 import com.algolia.search.models.common.RetryOutcome;
 import java.util.Collections;
@@ -21,11 +22,16 @@ class RetryStrategyTest {
     List<StatefulHost> hosts = retryStrategy.getTryableHosts(callType);
     assertThat(hosts).filteredOn(StatefulHost::isUp).hasSize(4);
 
-    RetryOutcome decision = retryStrategy.decide(hosts.get(0), httpCode, false);
+    RetryOutcome decision =
+        retryStrategy.decide(hosts.get(0), new HttpResponse(false).setHttpStatusCode(httpCode));
     assertThat(decision).isEqualTo(RetryOutcome.RETRY);
 
     List<StatefulHost> updatedHosts = retryStrategy.getTryableHosts(callType);
     assertThat(updatedHosts).filteredOn(StatefulHost::isUp).hasSize(3);
+
+    RetryOutcome decisionAfterNetworkError =
+        retryStrategy.decide(hosts.get(0), new HttpResponse().setNetworkError(true));
+    assertThat(decisionAfterNetworkError).isEqualTo(RetryOutcome.RETRY);
   }
 
   @ParameterizedTest
@@ -37,7 +43,8 @@ class RetryStrategyTest {
     List<StatefulHost> hosts = retryStrategy.getTryableHosts(callType);
     assertThat(hosts).filteredOn(StatefulHost::isUp).hasSize(4);
 
-    RetryOutcome decision = retryStrategy.decide(hosts.get(0), httpCode, false);
+    RetryOutcome decision =
+        retryStrategy.decide(hosts.get(0), new HttpResponse(false).setHttpStatusCode(httpCode));
     assertThat(decision).isEqualTo(RetryOutcome.FAILURE);
   }
 
@@ -50,7 +57,7 @@ class RetryStrategyTest {
     List<StatefulHost> hosts = retryStrategy.getTryableHosts(callType);
     assertThat(hosts).filteredOn(StatefulHost::isUp).hasSize(4);
 
-    RetryOutcome decision = retryStrategy.decide(hosts.get(0), 0, true);
+    RetryOutcome decision = retryStrategy.decide(hosts.get(0), new HttpResponse(true));
     assertThat(decision).isEqualTo(RetryOutcome.RETRY);
   }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

The requester was not catching correctly all exceptions, making the
retry strategy to fail instead of retrying for network related issues.

Apache HTTP client related materials:

Documentation about exception thrown by Apache HTTP client:
https://hc.apache.org/httpcomponents-core-4.4.x/tutorial/html/blocking-io.html#d5e375

(Legacy doc but some exceptions are still up-to-date)
https://hc.apache.org/httpclient-3.x/exception-handling.html
