### PR TITLE
internal: query serializer

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/QuerySerializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/QuerySerializer.java
@@ -1,13 +1,10 @@
 package com.algolia.search.models.indexing;
 
-import com.algolia.search.Defaults;
 import com.algolia.search.util.QueryStringUtils;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
-import java.util.Map;
 
 /** Customer serializer to serialize an Algolia search query as URL parameters */
 public class QuerySerializer extends StdSerializer<Query> {
@@ -23,8 +20,6 @@ public class QuerySerializer extends StdSerializer<Query> {
   @Override
   public void serialize(Query value, JsonGenerator gen, SerializerProvider provider)
       throws IOException {
-    Map<String, String> map =
-        Defaults.getObjectMapper().convertValue(value, new TypeReference<Map<String, String>>() {});
-    gen.writeString(QueryStringUtils.buildQueryString(map, true));
+    gen.writeString(QueryStringUtils.buildQueryAsQueryParams(value));
   }
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
@@ -116,10 +116,4 @@ public class QueryStringUtils {
         .map(p -> urlEncodeUTF8(p.getKey()) + "=" + urlEncodeUTF8(p.getValue()))
         .reduce((p1, p2) -> p1 + "&" + p2);
   }
-
-  private static String buildString(Map<String, String> map, String... ignoreList) {
-    HashMap<String, String> copy = new HashMap<>(map);
-    copy.keySet().removeAll(Arrays.asList(ignoreList));
-    return buildQueryString(copy);
-  }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change
`QuerySerializer` is now calling the new `buildQueryAsQueryParams`method. 
This PR removes unused private methods
