### PR TITLE
internal: fix bad naming for batching test

### DIFF
--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/index/BatchingTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/index/BatchingTest.java
@@ -1,5 +1,6 @@
 package com.algolia.search.integration.index;
 
+import static com.algolia.search.integration.TestHelpers.getTestIndexName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;
@@ -30,7 +31,7 @@ public abstract class BatchingTest {
   @Test
   void testBatching() throws ExecutionException, InterruptedException {
     SearchIndex<ObjectToBatch> index =
-        searchClient.initIndex("index_batching", ObjectToBatch.class);
+        searchClient.initIndex(getTestIndexName("index_batching"), ObjectToBatch.class);
 
     List<ObjectToBatch> batchOne =
         Arrays.asList(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes (in the test suite)
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

The batching test was wrongly named causing the test to fail with the CI and locally.