### PR TITLE
Travis: updates jdk to openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: java
 
 matrix:
   include:
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: JAVA_VERSION=8
-  - jdk: oraclejdk11
+  - jdk: openjdk11
     env: JAVA_VERSION=11
 
 cache:


### PR DESCRIPTION
## Describe your change

Use `openjdk` instead of `oraclejdk` because travis sometime fails to retrieve `oraclejdk`.