### PR TITLE
Feat/index languages

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/settings/IndexSettings.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/settings/IndexSettings.java
@@ -27,6 +27,7 @@ public class IndexSettings implements Serializable {
   private Integer maxFacetHits;
   private String keepDiacriticsOnCharacters;
   private List<String> queryLanguages;
+  private List<String> indexLanguages;
 
   private List<String> searchableAttributes;
   private List<String> attributesForFaceting;
@@ -629,6 +630,15 @@ public class IndexSettings implements Serializable {
 
   public IndexSettings setQueryLanguages(List<String> queryLanguages) {
     this.queryLanguages = queryLanguages;
+    return this;
+  }
+
+  public List<String> getIndexLanguages() {
+    return indexLanguages;
+  }
+
+  public IndexSettings setIndexLanguages(List<String> indexLanguages) {
+    this.indexLanguages = indexLanguages;
     return this;
   }
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/index/SettingsTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/index/SettingsTest.java
@@ -102,6 +102,7 @@ public abstract class SettingsTest {
     settings.setDisableExactOnAttributes(Arrays.asList("attribute1", "attribute2"));
     settings.setExactOnSingleWordQuery("word");
     settings.setQueryLanguages(Arrays.asList("fr", "en"));
+    settings.setIndexLanguages(Collections.singletonList("ja"));
     settings.setAdvancedSyntaxFeatures(Collections.singletonList("exactPhrase"));
 
     // Query rules


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #610
| Need Doc update   | yes


## Describe your change

Implement the new `indexLanguages` setting which is an array of strings.
Currently, only `["ja"]` is supported by the engine.