### PR TITLE
feat(queryRules/alternatives)

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Alternatives.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Alternatives.java
@@ -1,0 +1,63 @@
+package com.algolia.search.models.rules;
+
+import com.algolia.search.models.CompoundType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Alternatives may transform into JSON object in the future. That's why it's implementing
+ * CompoundType.
+ */
+@JsonDeserialize(using = AlternativesDeserializer.class)
+@JsonSerialize(using = AlternativesSerializer.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Alternatives implements Serializable, CompoundType {
+
+  public static Alternatives of(Boolean bool) {
+    return new AlternativesBoolean(bool);
+  }
+
+  @Override
+  public int hashCode() {
+    return getInsideValue() != null ? getInsideValue().hashCode() : 0;
+  }
+}
+
+class AlternativesBoolean extends Alternatives {
+  private final boolean insideValue;
+
+  AlternativesBoolean(boolean insideValue) {
+    this.insideValue = insideValue;
+  }
+
+  @Override
+  public Object getInsideValue() {
+    return insideValue;
+  }
+}
+
+class AlternativesDeserializer extends JsonDeserializer<Alternatives> {
+  @Override
+  public Alternatives deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    return Alternatives.of(p.getBooleanValue());
+  }
+}
+
+class AlternativesSerializer extends JsonSerializer<Alternatives> {
+  @Override
+  public void serialize(Alternatives value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    if (value instanceof AlternativesBoolean) {
+      gen.writeBoolean((Boolean) value.getInsideValue());
+    }
+  }
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Condition.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Condition.java
@@ -13,6 +13,7 @@ public class Condition implements Serializable {
   private String pattern;
   private String anchoring;
   private String context;
+  private Alternatives alternatives;
 
   public Condition() {}
 
@@ -40,6 +41,15 @@ public class Condition implements Serializable {
 
   public Condition setContext(String context) {
     this.context = context;
+    return this;
+  }
+
+  public Alternatives getAlternatives() {
+    return alternatives;
+  }
+
+  public Condition setAlternatives(Alternatives alternatives) {
+    this.alternatives = alternatives;
     return this;
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/index/QueryRulesTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/index/QueryRulesTest.java
@@ -94,7 +94,11 @@ public abstract class QueryRulesTest {
     Rule ruleToSave2 =
         new Rule()
             .setObjectID("query_edits")
-            .setCondition(new Condition().setAnchoring("is").setPattern("mobile phone"))
+            .setCondition(
+                new Condition()
+                    .setAnchoring("is")
+                    .setPattern("mobile phone")
+                    .setAlternatives(Alternatives.of(true)))
             .setConsequence(consequenceToBatch);
 
     // Sending rules request


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #611
| Need Doc update   | yes

## Changes

This PR adds the`Alternatives` parameter in QueryRules conditions

`Alternatives` may transform into JSON object in the future, that's why it's implementing `CompoundType`.

