### PR TITLE
feat(builder/Proxy)

### DIFF
--- a/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
+++ b/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
@@ -47,7 +47,11 @@ final class ApacheHttpRequester implements HttpRequester {
             .setContentCompressionEnabled(true)
             .build();
 
-    asyncHttpClient = HttpAsyncClients.createDefault();
+    asyncHttpClient =
+        config.getUseSystemProxy()
+            ? HttpAsyncClients.createSystem()
+            : HttpAsyncClients.createDefault();
+
     asyncHttpClient.start();
   }
 

--- a/algoliasearch-core/src/main/java/com/algolia/search/ConfigBase.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/ConfigBase.java
@@ -19,6 +19,7 @@ public abstract class ConfigBase {
   private final String apiKey;
   private final Map<String, String> defaultHeaders;
   private final int batchSize;
+  private final boolean useSystemProxy;
   private final Integer readTimeOut;
   private final Integer writeTimeOut;
   private final Integer connectTimeOut;
@@ -33,6 +34,7 @@ public abstract class ConfigBase {
     private final String apiKey;
     private final Map<String, String> defaultHeaders;
     private int batchSize;
+    private boolean useSystemProxy;
     private Integer readTimeOut;
     private Integer writeTimeOut;
     private Integer connectTimeOut;
@@ -57,6 +59,7 @@ public abstract class ConfigBase {
       this.applicationID = applicationID;
       this.apiKey = apiKey;
 
+      this.useSystemProxy = false;
       this.batchSize = 1000;
       this.hosts = defaultHosts;
       this.connectTimeOut = Defaults.CONNECT_TIMEOUT_MS;
@@ -77,6 +80,12 @@ public abstract class ConfigBase {
 
     /** To prevent unchecked cast warning. */
     public abstract T getThis();
+
+    /** Makes the underlying HTTP Client to use JVM/System settings for the proxy */
+    public T setUseSystemProxy(boolean useSystemProxy) {
+      this.useSystemProxy = useSystemProxy;
+      return getThis();
+    }
 
     /** Overrides the default batch size for save methods. Default = 1000 objects per chunk. */
     public T setBatchSize(int batchSize) {
@@ -150,6 +159,7 @@ public abstract class ConfigBase {
     this.apiKey = builder.apiKey;
     this.applicationID = builder.applicationID;
     this.defaultHeaders = builder.defaultHeaders;
+    this.useSystemProxy = builder.useSystemProxy;
     this.batchSize = builder.batchSize;
     this.compressionType = builder.compressionType;
     this.readTimeOut = builder.readTimeOut;
@@ -169,6 +179,10 @@ public abstract class ConfigBase {
 
   public Map<String, String> getDefaultHeaders() {
     return defaultHeaders;
+  }
+
+  public boolean getUseSystemProxy() {
+    return useSystemProxy;
   }
 
   public int getBatchSize() {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes

## Describe your change

Adds the possibility for the underlying HTTPClient to use JVM settings
for proxy such as:

```
System.setProperty("http.proxyHost", getHTTPHost());
System.setProperty("http.proxyPort", getHTTPPort());
System.setProperty("https.proxyHost", getHTTPHost());
System.setProperty("https.proxyPort", getHTTPPort());
System.setProperty("http.proxyUser", getAuthUser());
System.setProperty("http.proxyPassword", getAuthPassword());
```

