### PR TITLE
fix: RemoveWordsType invalid casing

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RemoveWordsType.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RemoveWordsType.java
@@ -4,11 +4,11 @@ public enum RemoveWordsType {
   // when a query does not return any result, the final word will be
   // removed until there is results. This option is useful on
   // e-commerce websites
-  REMOVE_LAST_WORDS("LastWords"),
+  REMOVE_LAST_WORDS("lastWords"),
   // when a query does not return any result, the first word will be
   // removed until there is results. This option is useful on address
   // search.
-  REMOVE_FIRST_WORDS("FirstWords"),
+  REMOVE_FIRST_WORDS("firstWords"),
   // No specific processing is done when a query does not return any
   // result.
   REMOVE_NONE("none"),


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #628 
| Need Doc update   | no


RemoveWordsType value must be camelCased.

- none
- lastWords
- firstWords
- allOptional
