### PR TITLE
fix: deserialization of legacy filters

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
@@ -1,0 +1,49 @@
+package com.algolia.search.models.indexing;
+
+import com.algolia.search.exceptions.AlgoliaRuntimeException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+class FiltersJsonDeserializer extends JsonDeserializer {
+
+  /**
+   * Algolia's specific deserializer handling multiple form of (legacy) filters This reader is
+   * converting single string to nested arrays. This reader is also converting single array to
+   * nested arrays
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+
+    JsonToken currentToken = p.getCurrentToken();
+
+    List<List<String>> result = null;
+
+    switch (currentToken) {
+      case START_ARRAY:
+        List list = p.readValueAs(List.class);
+        if (list.get(0) instanceof String) {
+          result = Collections.singletonList(list);
+        } else {
+          result = list;
+        }
+        break;
+      case VALUE_STRING:
+        result = Collections.singletonList(Arrays.asList(p.getValueAsString().split(",")));
+        break;
+      case VALUE_NULL:
+        break;
+      default:
+        throw new AlgoliaRuntimeException(
+            "Unexpected JSON format occurred during the deserialization of filters.");
+    }
+
+    return result;
+  }
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
@@ -6,6 +6,7 @@ import com.algolia.search.models.settings.RemoveStopWords;
 import com.algolia.search.models.settings.TypoTolerance;
 import com.algolia.search.util.QueryStringUtils;
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -643,8 +644,13 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
   /* advanced */
   protected Distinct distinct;
   protected Boolean getRankingInfo;
+
+  @JsonDeserialize(using = FiltersJsonDeserializer.class)
   protected List<List<String>> numericFilters;
+
+  @JsonDeserialize(using = FiltersJsonDeserializer.class)
   protected List<List<String>> tagFilters;
+
   protected Boolean clickAnalytics;
   protected Boolean analytics;
   protected List<String> analyticsTags;
@@ -664,8 +670,13 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
   protected String filters;
   protected List<String> facets;
   protected Long maxValuesPerFacet;
+
+  @JsonDeserialize(using = FiltersJsonDeserializer.class)
   protected List<List<String>> facetFilters;
+
+  @JsonDeserialize(using = FiltersJsonDeserializer.class)
   protected List<List<String>> optionalFilters;
+
   protected Boolean facetingAfterDistinct;
   protected String sortFacetValuesBy;
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #627 
| Need Doc update   | yes/no


## Describe your change

Legacy form of filters were not supported by the Deserializer.

one string legacy filters "color:green,color:yellow" are converted
to "ORED" nested filters `[["color:green","color:yellow"]]`

array legacy filters `["color:green","color:yellow"]` are converted
to "ORED" nested filters `[["color:green","color:yellow"]]`

This PR is adding a new Deserializer handling the legacy filters and the related test suite.