### PR TITLE
feat: add enableABTest

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
@@ -614,6 +614,15 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
     return getThis();
   }
 
+  public Boolean getEnableABTest() {
+    return enableABTest;
+  }
+
+  public T setEnableABTest(Boolean enableABTest) {
+    this.enableABTest = enableABTest;
+    return getThis();
+  }
+
   @JsonAnyGetter
   public Map<String, Object> getCustomParameters() {
     return customParameters;
@@ -742,6 +751,9 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
   /* Personalization */
   protected Boolean enablePersonalization;
   protected Integer personalizationImpact;
+
+  /* Analytics */
+  protected Boolean enableABTest;
 
   /* Custom Parameters */
   protected Map<String, Object> customParameters = new HashMap<>();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #642
| Need Doc update   | no


## Describe your change

Add the enableABTest query-time only parameter.
Defaults to true so that A/B tests are applied by default.
Can be set to false to disable A/B tests at query time.


