### PR TITLE
feat(query): explain decompounding at query time

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Alternative.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Alternative.java
@@ -1,0 +1,56 @@
+package com.algolia.search.models.indexing;
+
+import java.util.List;
+
+public class Alternative {
+  public String getType() {
+    return type;
+  }
+
+  public Alternative setType(String type) {
+    this.type = type;
+    return this;
+  }
+
+  public List<String> getWords() {
+    return words;
+  }
+
+  public Alternative setWords(List<String> words) {
+    this.words = words;
+    return this;
+  }
+
+  public Long getTypos() {
+    return typos;
+  }
+
+  public Alternative setTypos(Long typos) {
+    this.typos = typos;
+    return this;
+  }
+
+  public Long getOffset() {
+    return offset;
+  }
+
+  public Alternative setOffset(Long offset) {
+    this.offset = offset;
+    return this;
+  }
+
+  public Long getLength() {
+    return length;
+  }
+
+  public Alternative setLength(Long length) {
+    this.length = length;
+    return this;
+  }
+
+  private String type;
+  private List<String> words;
+  private Long typos;
+  private Long offset;
+  private Long length;
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Explain.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Explain.java
@@ -1,0 +1,18 @@
+package com.algolia.search.models.indexing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Explain {
+
+  public QueryMatch getQueryMatch() {
+    return queryMatch;
+  }
+
+  public Explain setQueryMatch(QueryMatch queryMatch) {
+    this.queryMatch = queryMatch;
+    return this;
+  }
+
+  @JsonProperty("match")
+  private QueryMatch queryMatch;
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Explain.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Explain.java
@@ -2,6 +2,8 @@ package com.algolia.search.models.indexing;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 public class Explain {
 
   public QueryMatch getQueryMatch() {
@@ -13,6 +15,16 @@ public class Explain {
     return this;
   }
 
+  public Map<String, Object> getParams() {
+    return params;
+  }
+
+  public Explain setParams(Map<String, Object> params) {
+    this.params = params;
+    return this;
+  }
+
   @JsonProperty("match")
   private QueryMatch queryMatch;
+  private Map<String,Object> params;
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/QueryMatch.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/QueryMatch.java
@@ -1,0 +1,16 @@
+package com.algolia.search.models.indexing;
+
+import java.util.List;
+
+public class QueryMatch {
+  public List<Alternative> getAlternatives() {
+    return alternatives;
+  }
+
+  public QueryMatch setAlternatives(List<Alternative> alternatives) {
+    this.alternatives = alternatives;
+    return this;
+  }
+
+  private List<Alternative> alternatives;
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
@@ -47,11 +47,11 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
     return getThis();
   }
 
-  public String getExplain() {
+  public List<String> getExplain() {
     return explain;
   }
 
-  public T setExplain(String explain) {
+  public T setExplain(List<String> explain) {
     this.explain = explain;
     return getThis();
   }
@@ -662,7 +662,7 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
   /* advanced */
   protected Distinct distinct;
   protected Boolean getRankingInfo;
-  protected String explain;
+  protected List<String> explain;
 
   @JsonDeserialize(using = FiltersJsonDeserializer.class)
   protected List<List<String>> numericFilters;

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchParameters.java
@@ -47,6 +47,15 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
     return getThis();
   }
 
+  public String getExplain() {
+    return explain;
+  }
+
+  public T setExplain(String explain) {
+    this.explain = explain;
+    return getThis();
+  }
+
   public List<List<String>> getNumericFilters() {
     return numericFilters;
   }
@@ -653,6 +662,7 @@ public abstract class SearchParameters<T extends SearchParameters<T>> implements
   /* advanced */
   protected Distinct distinct;
   protected Boolean getRankingInfo;
+  protected String explain;
 
   @JsonDeserialize(using = FiltersJsonDeserializer.class)
   protected List<List<String>> numericFilters;

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchResult.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchResult.java
@@ -25,8 +25,18 @@ public class SearchResult<T> implements Serializable {
   private String index;
   private Boolean processed;
   private String queryID;
+  private Explain explain;
   private List<Map<String, Object>> userData;
   private List<Map<String, Object>> appliedRules;
+
+  public Explain getExplain() {
+    return explain;
+  }
+
+  public SearchResult<T> setExplain(Explain explain) {
+    this.explain = explain;
+    return this;
+  }
 
   public Long getOffset() {
     return offset;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #648
| Need Doc update   | yes/no


## Describe your change

adds the `Explain` parameter & response field.
Waiting for the end of the beta to add the test. 
