### PR TITLE
patch: generateSecuredAPIKey

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
@@ -8,6 +8,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 public class QueryStringUtils {
 
@@ -95,11 +96,20 @@ public class QueryStringUtils {
     return buildQueryString(newMap, true);
   }
 
-  static String buildRestrictionQueryString(SecuredApiKeyRestriction restriction) {
-    Map<String, String> map =
+  static String buildRestrictionQueryString(@Nonnull final SecuredApiKeyRestriction restriction) {
+
+    Map<String, String> restrictionMap =
         Defaults.getObjectMapper()
             .convertValue(restriction, new TypeReference<Map<String, String>>() {});
-    return buildQueryString(map, true);
+
+    if (restriction.getQuery() != null) {
+      restrictionMap.remove("query");
+      return buildQueryString(restrictionMap, true)
+          + "&"
+          + buildQueryAsQueryParams(restriction.getQuery());
+    }
+
+    return buildQueryString(restrictionMap, true);
   }
 
   private static String formatParameters(Object parameter) {

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/client/SecuredAPIKeyTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/client/SecuredAPIKeyTest.java
@@ -1,6 +1,7 @@
 package com.algolia.search.integration.client;
 
 import static com.algolia.search.integration.TestHelpers.getTestIndexName;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.algolia.search.SearchClient;
@@ -11,6 +12,8 @@ import com.algolia.search.models.indexing.BatchIndexingResponse;
 import com.algolia.search.models.indexing.Query;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
@@ -60,5 +63,25 @@ public abstract class SecuredAPIKeyTest {
     } finally {
       index2.deleteAsync();
     }
+  }
+
+  @Test
+  void securedAPIKeyWithQuery() throws Exception {
+
+    final Query query =
+        new Query()
+            .setTagFilters(Collections.singletonList(Arrays.asList("87", "1033", "1052", "1534")))
+            .setUserToken("70");
+
+    final SecuredApiKeyRestriction restrictions =
+        new SecuredApiKeyRestriction().setQuery(query).setValidUntil(1000L);
+
+    String securedAPIKey = searchClient.generateSecuredAPIKey("ALGOLIA_SEARCH_KEY_1", restrictions);
+    byte[] decodedBytes = Base64.getDecoder().decode(securedAPIKey);
+    String decodedString = new String(decodedBytes);
+
+    assertThat(decodedString)
+        .containsSubsequence(
+            "validUntil=1000&userToken=70&tagFilters=%5B%5B%2287%22%2C%221033%22%2C%221052%22%2C%221534%22%5D%5D");
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #657 
| Need Doc update   | no

## Describe your change

The securedAPIKey was not written correctly when used with a query
parameter. `buildRestrictionQueryString` was writing "query" as
a nested object but it should be at the same level as "restriction".