### PR TITLE
patch: serialization/deserialization of ConsequenceQuery

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceParams.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceParams.java
@@ -53,12 +53,8 @@ public class ConsequenceParams extends SearchParameters<ConsequenceParams> {
   @Override
   @JsonIgnore
   public ConsequenceParams setQuery(String query) {
-
-    if (this.query == null) {
-      this.query = new ConsequenceQuery();
-      this.query.setQueryString(query);
-    }
-
+    this.query = new ConsequenceQuery();
+    this.query.setQueryString(query);
     return this;
   }
 

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceParams.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceParams.java
@@ -1,9 +1,7 @@
 package com.algolia.search.models.rules;
 
 import com.algolia.search.models.indexing.SearchParameters;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
@@ -16,24 +14,57 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConsequenceParams extends SearchParameters<ConsequenceParams> {
 
-  private ConsequenceQuery query;
-
-  @JsonDeserialize(using = AutomaticFacetFilterDeserializer.class)
-  private List<AutomaticFacetFilter> automaticFacetFilters;
-
-  @JsonDeserialize(using = AutomaticFacetFilterDeserializer.class)
-  private List<AutomaticFacetFilter> automaticOptionalFacetFilters;
-
   public ConsequenceParams() {}
 
-  @JsonProperty("query")
+  @JsonGetter("query")
   public ConsequenceQuery getConsequenceQuery() {
     return query;
   }
 
-  @JsonProperty("query")
+  /**
+   * Providing a {@link ConsequenceQuery} will describe incremental edits to be made to the query.
+   *
+   * <p><b>Important NOTE:</b> Setting a ConsequenceQuery will override regular "query" if set. Both
+   * can't be set at the same time.
+   */
+  @JsonSetter("query")
   public ConsequenceParams setConsequenceQuery(ConsequenceQuery consequenceQuery) {
     this.query = consequenceQuery;
+    return this;
+  }
+
+  @Override
+  @JsonIgnore
+  public String getQuery() {
+
+    if (this.query != null) {
+      return this.query.getQueryString();
+    }
+
+    return null;
+  }
+
+  /**
+   * When providing a string, it replaces the entire query string.
+   *
+   * <p><b>Important NOTE:</b> Setting a Query String will override any ConsequenceQuery set before.
+   * Both can't be set at the same time.
+   */
+  @Override
+  @JsonIgnore
+  public ConsequenceParams setQuery(String query) {
+
+    if (this.query == null) {
+      this.query = new ConsequenceQuery();
+      this.query.setQueryString(query);
+    }
+
+    return this;
+  }
+
+  @Override
+  @JsonIgnore
+  public ConsequenceParams getThis() {
     return this;
   }
 
@@ -57,9 +88,11 @@ public class ConsequenceParams extends SearchParameters<ConsequenceParams> {
     return this;
   }
 
-  @Override
-  @JsonIgnore
-  public ConsequenceParams getThis() {
-    return this;
-  }
+  private ConsequenceQuery query;
+
+  @JsonDeserialize(using = AutomaticFacetFilterDeserializer.class)
+  private List<AutomaticFacetFilter> automaticFacetFilters;
+
+  @JsonDeserialize(using = AutomaticFacetFilterDeserializer.class)
+  private List<AutomaticFacetFilter> automaticOptionalFacetFilters;
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceQuery.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceQuery.java
@@ -1,14 +1,19 @@
 package com.algolia.search.models.rules;
 
 import com.algolia.search.Defaults;
+import com.algolia.search.util.AlgoliaUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,9 +24,10 @@ import java.util.stream.Collectors;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonDeserialize(using = ConsequenceQueryDeserializer.class)
+@JsonSerialize(using = ConsequenceQuerySerializer.class)
 public class ConsequenceQuery implements Serializable {
 
-  private List<Edit> edits;
+  public ConsequenceQuery() {}
 
   public List<Edit> getEdits() {
     return edits;
@@ -31,29 +37,118 @@ public class ConsequenceQuery implements Serializable {
     this.edits = edits;
     return this;
   }
+
+  String getQueryString() {
+    return queryString;
+  }
+
+  ConsequenceQuery setQueryString(String queryString) {
+    this.queryString = queryString;
+    return this;
+  }
+
+  private List<Edit> edits;
+  private String queryString;
 }
 
+/**
+ * Custom serializer to handle polymorphism/legacy of "query" attributes in ConsequenceQuery
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ *  // query string
+ *  "query": "some query string"
+ *
+ *  // remove attribute (deprecated)
+ *  "query": {"remove": ["query1", "query2"]}
+ *
+ *  // edits attribute
+ *  "query": {
+ *     "edits": [
+ *        { "type": "remove", "delete": "old" },
+ *        { "type": "replace", "delete": "new", "insert": "newer" }
+ *     ]
+ * }
+ * }</pre>
+ */
+class ConsequenceQuerySerializer extends JsonSerializer<ConsequenceQuery> {
+  @Override
+  public void serialize(ConsequenceQuery value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    /*
+     * Consequence query edits will override regular "query" - both can't be set at the same time
+     * https://www.algolia.com/doc/api-reference/api-methods/save-rule/#method-param-query
+     * */
+    if (!AlgoliaUtils.isNullOrEmptyWhiteSpace(value.getQueryString())) {
+      gen.writeString(value.getQueryString());
+    } else {
+      gen.writeStartObject();
+      gen.writeObjectField("edits", value.getEdits());
+      gen.writeEndObject();
+    }
+  }
+}
+
+/**
+ * Custom deserializer to handle polymorphism/legacy of "query" attributes in ConsequenceQuery
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ *  // query string
+ *  "query": "some query string"
+ *
+ *  // remove attribute (deprecated)
+ *  "query": {"remove": ["query1", "query2"]}
+ *
+ *  // edits attribute
+ *  "query": {
+ *     "edits": [
+ *        { "type": "remove", "delete":s "old" },
+ *        { "type": "replace", "delete": "new", "insert": "newer" }
+ *     ]
+ * }
+ * }</pre>
+ *
+ * <b>NOTE</b>: this deserializer is "silently" converting deprecated "remove" to "edits"
+ * consequence query
+ */
 class ConsequenceQueryDeserializer extends JsonDeserializer<ConsequenceQuery> {
   @Override
   public ConsequenceQuery deserialize(JsonParser jp, DeserializationContext ctxt)
       throws IOException {
+
     ObjectCodec oc = jp.getCodec();
     JsonNode node = oc.readTree(jp);
     ObjectMapper objectMapper = Defaults.getObjectMapper();
 
-    if (node.has("edits")) {
-      ObjectReader reader = objectMapper.readerFor(new TypeReference<List<Edit>>() {});
-      List<Edit> list = reader.readValue(node.get("edits"));
-      return new ConsequenceQuery().setEdits(list);
+    // edits and remove attribute
+    if (node.isObject()) {
+
+      ConsequenceQuery ret = new ConsequenceQuery();
+      List<Edit> edits = new ArrayList<>(Collections.emptyList());
+
+      if (node.findValue("remove") != null) {
+        // remove attributes deprecated
+        ObjectReader reader = objectMapper.readerFor(new TypeReference<List<String>>() {});
+        List<String> list = reader.readValue(node.get("remove"));
+        List<Edit> remove =
+            list.stream().map(r -> new Edit(EditType.REMOVE, r, null)).collect(Collectors.toList());
+        edits.addAll(remove);
+      }
+
+      if (node.findValue("edits") != null) {
+        ObjectReader reader = objectMapper.readerFor(new TypeReference<List<Edit>>() {});
+        List<Edit> list = reader.readValue(node.get("edits"));
+        edits.addAll(list);
+      }
+
+      ret.setEdits(edits);
+      return ret;
     } else {
-
-      ObjectReader reader = objectMapper.readerFor(new TypeReference<List<String>>() {});
-      List<String> list = reader.readValue(node);
-
-      List<Edit> edits =
-          list.stream().map(r -> new Edit(EditType.REMOVE, r, null)).collect(Collectors.toList());
-
-      return new ConsequenceQuery().setEdits(edits);
+      // query string
+      return new ConsequenceQuery().setQueryString(node.asText());
     }
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #662 
| Need Doc update   | no


## Problem
The custom serializer was not handling all the cases for the payload below.

Example:

```json
// query string
"query": "some query string"

// remove attribute (deprecated)
"query": {"remove": ["query1", "query2"]}

// edits attribute
"query": {
   "edits": [
     { "type": "remove", "delete": "old" },
     { "type": "replace", "delete": "new", "insert": "newer" }
   ]
}}
```

## Fix

I added a `string` property in `ConsequenceQuery` and modified the serializer to allow `ConsequenceQuery` to deserialize and serializer Query as string. This required to overload `setQuery` and `getQuery` from `SearchParameters`
