### PR TITLE
feat: adds JDK11 java-net requester

### DIFF
--- a/.run-travis.sh
+++ b/.run-travis.sh
@@ -18,7 +18,7 @@ if [[ "${JAVA_VERSION}" = "11" ]]; then
     eval $(./algolia-keys export) && mvn clean compile && mvn clean test;
     exit $?
   else
-    mvn clean compile & mvn clean test;
+    mvn clean compile && mvn clean test;
     exit $?
   fi
 fi

--- a/.run-travis.sh
+++ b/.run-travis.sh
@@ -4,20 +4,21 @@ set -e
 
 if [[ "${JAVA_VERSION}" = "8" ]]; then
   if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then
-    eval $(./algolia-keys export) && mvn clean test;
+    # test only JDK8 comptaible requester
+    eval $(./algolia-keys export) && mvn clean compile -pl algoliasearch-apache,algoliasearch-core &&  mvn clean test -pl algoliasearch-apache,algoliasearch-core;
     exit $?
   else
-    mvn clean test;
+    mvn clean compile -pl algoliasearch-apache,algoliasearch-core && mvn clean test -pl algoliasearch-apache,algoliasearch-core;
     exit $?
   fi
 fi
 
 if [[ "${JAVA_VERSION}" = "11" ]]; then
   if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^algolia\/ ]]; then
-    eval $(./algolia-keys export) && mvn clean test;
+    eval $(./algolia-keys export) && mvn clean compile && mvn clean test;
     exit $?
   else
-    mvn clean test;
+    mvn clean compile & mvn clean test;
     exit $?
   fi
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ matrix:
     env: JAVA_VERSION=8
   - jdk: openjdk11
     env: JAVA_VERSION=11
-
 cache:
   directories:
   - $HOME/.m2
+
+install: skip # skipping default travis setup to support both JDK8 and JDK11 build. Default build would fail.
 
 #check coverage
 before_script:

--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -59,7 +59,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
@@ -1,17 +1,14 @@
 package com.algolia.search;
 
+
 import com.algolia.search.integration.TestHelpers;
 import com.algolia.search.models.common.CompressionType;
-<<<<<<< HEAD
-import java.io.IOException;
-=======
->>>>>>> afc1c01... update: apache test suite
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.io.IOException;
 
 import static com.algolia.search.integration.TestHelpers.*;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class IntegrationTestExtension
     implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
@@ -22,12 +19,12 @@ public class IntegrationTestExtension
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
     TestHelpers.checkEnvironmentVariable();
-    searchClient = DefaultSearchClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+    searchClient = DefaultSearchClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1);
     // Disabling gzip for client2 because GZip not is not enabled yet on the server
     SearchConfig client2Config =
-            new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_2, ALGOLIA_API_KEY_2)
-                    .setCompressionType(CompressionType.NONE)
-                    .build();
+        new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_2, ALGOLIA_ADMIN_KEY_2)
+            .setCompressionType(CompressionType.NONE)
+            .build();
     searchClient2 = DefaultSearchClient.create(client2Config);
   }
 
@@ -39,4 +36,5 @@ public class IntegrationTestExtension
     } catch (IOException ignored) {
     }
   }
+
 }

--- a/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
@@ -1,12 +1,10 @@
 package com.algolia.search;
 
+import static com.algolia.search.integration.TestHelpers.*;
 
 import com.algolia.search.integration.TestHelpers;
 import com.algolia.search.models.common.CompressionType;
 import java.io.IOException;
-
-import static com.algolia.search.integration.TestHelpers.*;
-
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -36,5 +34,4 @@ public class IntegrationTestExtension
     } catch (IOException ignored) {
     }
   }
-
 }

--- a/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
@@ -2,9 +2,16 @@ package com.algolia.search;
 
 import com.algolia.search.integration.TestHelpers;
 import com.algolia.search.models.common.CompressionType;
+<<<<<<< HEAD
 import java.io.IOException;
+=======
+>>>>>>> afc1c01... update: apache test suite
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+
+import static com.algolia.search.integration.TestHelpers.*;
 
 public class IntegrationTestExtension
     implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
@@ -12,23 +19,15 @@ public class IntegrationTestExtension
   public static SearchClient searchClient;
   public static SearchClient searchClient2;
 
-  public static String ALGOLIA_APPLICATION_ID_1 = System.getenv("ALGOLIA_APPLICATION_ID_1");
-  public static String ALGOLIA_API_KEY_1 = System.getenv("ALGOLIA_ADMIN_KEY_1");
-  public static String ALGOLIA_SEARCH_KEY_1 = System.getenv("ALGOLIA_SEARCH_KEY_1");
-  private static String ALGOLIA_APPLICATION_ID_2 = System.getenv("ALGOLIA_APPLICATION_ID_2");
-  private static String ALGOLIA_API_KEY_2 = System.getenv("ALGOLIA_ADMIN_KEY_2");
-  public static String ALGOLIA_APPLICATION_ID_MCM = System.getenv("ALGOLIA_APPLICATION_ID_MCM");
-  public static String ALGOLIA_ADMIN_KEY_MCM = System.getenv("ALGOLIA_ADMIN_KEY_MCM");
-
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
     TestHelpers.checkEnvironmentVariable();
     searchClient = DefaultSearchClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
     // Disabling gzip for client2 because GZip not is not enabled yet on the server
     SearchConfig client2Config =
-        new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_2, ALGOLIA_API_KEY_2)
-            .setCompressionType(CompressionType.NONE)
-            .build();
+            new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_2, ALGOLIA_API_KEY_2)
+                    .setCompressionType(CompressionType.NONE)
+                    .build();
     searchClient2 = DefaultSearchClient.create(client2Config);
   }
 

--- a/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/IntegrationTestExtension.java
@@ -1,14 +1,8 @@
 package com.algolia.search;
 
+import com.algolia.search.integration.TestHelpers;
 import com.algolia.search.models.common.CompressionType;
-import com.algolia.search.models.indexing.ActionEnum;
-import com.algolia.search.models.indexing.BatchOperation;
-import com.algolia.search.models.indexing.IndicesResponse;
 import java.io.IOException;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -28,7 +22,7 @@ public class IntegrationTestExtension
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
-    checkEnvironmentVariable();
+    TestHelpers.checkEnvironmentVariable();
     searchClient = DefaultSearchClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
     // Disabling gzip for client2 because GZip not is not enabled yet on the server
     SearchConfig client2Config =
@@ -44,36 +38,6 @@ public class IntegrationTestExtension
       searchClient2.close();
       searchClient.close();
     } catch (IOException ignored) {
-    }
-  }
-
-  private static void checkEnvironmentVariable() throws Exception {
-    if (ALGOLIA_APPLICATION_ID_1 == null || ALGOLIA_APPLICATION_ID_1.isEmpty()) {
-      throw new Exception("ALGOLIA_APPLICATION_ID is not defined or empty");
-    }
-
-    if (ALGOLIA_API_KEY_1 == null || ALGOLIA_API_KEY_1.isEmpty()) {
-      throw new Exception("ALGOLIA_API_KEY is not defined or empty");
-    }
-
-    if (ALGOLIA_SEARCH_KEY_1 == null || ALGOLIA_SEARCH_KEY_1.isEmpty()) {
-      throw new Exception("ALGOLIA_SEARCH_KEY_1 is not defined or empty");
-    }
-
-    if (ALGOLIA_APPLICATION_ID_2 == null || ALGOLIA_APPLICATION_ID_2.isEmpty()) {
-      throw new Exception("ALGOLIA_APPLICATION_ID_2 is not defined or empty");
-    }
-
-    if (ALGOLIA_API_KEY_2 == null || ALGOLIA_API_KEY_2.isEmpty()) {
-      throw new Exception("ALGOLIA_API_KEY_2 is not defined or empty");
-    }
-
-    if (ALGOLIA_APPLICATION_ID_MCM == null || ALGOLIA_APPLICATION_ID_MCM.isEmpty()) {
-      throw new Exception("ALGOLIA_APPLICATION_ID_MCM is not defined or empty");
-    }
-
-    if (ALGOLIA_ADMIN_KEY_MCM == null || ALGOLIA_ADMIN_KEY_MCM.isEmpty()) {
-      throw new Exception("ALGOLIA_ADMIN_KEY_MCM is not defined or empty");
     }
   }
 }

--- a/algoliasearch-apache/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.analytics;
 
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
 import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.AnalyticsClient;
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class AnalyticsTest extends com.algolia.search.integration.analytics.AnalyticsTest {
 
   private static AnalyticsClient analyticsClient =
-      DefaultAnalyticsClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+      DefaultAnalyticsClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1);
 
   AnalyticsTest() {
     super(IntegrationTestExtension.searchClient, analyticsClient);

--- a/algoliasearch-apache/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
@@ -1,7 +1,7 @@
 package com.algolia.search.analytics;
 
-import static com.algolia.search.IntegrationTestExtension.ALGOLIA_API_KEY_1;
-import static com.algolia.search.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.AnalyticsClient;
 import com.algolia.search.DefaultAnalyticsClient;

--- a/algoliasearch-apache/src/test/java/com/algolia/search/client/MultiClusterManagementTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/client/MultiClusterManagementTest.java
@@ -1,5 +1,8 @@
 package com.algolia.search.client;
 
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_MCM;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_MCM;
+
 import com.algolia.search.DefaultSearchClient;
 import com.algolia.search.IntegrationTestExtension;
 import java.io.IOException;
@@ -13,10 +16,7 @@ class MultiClusterManagementTest
     extends com.algolia.search.integration.client.MultiClusterManagementTest {
 
   MultiClusterManagementTest() {
-    super(
-        DefaultSearchClient.create(
-            IntegrationTestExtension.ALGOLIA_APPLICATION_ID_MCM,
-            IntegrationTestExtension.ALGOLIA_ADMIN_KEY_MCM));
+    super(DefaultSearchClient.create(ALGOLIA_APPLICATION_ID_MCM, ALGOLIA_ADMIN_KEY_MCM));
   }
 
   @AfterAll

--- a/algoliasearch-apache/src/test/java/com/algolia/search/client/SecuredAPIKeyTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/client/SecuredAPIKeyTest.java
@@ -1,6 +1,8 @@
 package com.algolia.search.client;
 
 import static com.algolia.search.IntegrationTestExtension.*;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_SEARCH_KEY_1;
 
 import com.algolia.search.DefaultSearchClient;
 import com.algolia.search.IntegrationTestExtension;

--- a/algoliasearch-apache/src/test/java/com/algolia/search/client/TimeoutTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/client/TimeoutTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.client;
 
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
 import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.DefaultSearchClient;
@@ -9,7 +9,7 @@ import com.algolia.search.SearchConfig;
 
 class TimeoutTest extends com.algolia.search.integration.client.TimeoutTest {
   protected SearchConfig.Builder createBuilder() {
-    return new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+    return new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1);
   }
 
   protected SearchClient createClient(SearchConfig config) {

--- a/algoliasearch-apache/src/test/java/com/algolia/search/client/TimeoutTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/client/TimeoutTest.java
@@ -1,7 +1,7 @@
 package com.algolia.search.client;
 
-import static com.algolia.search.IntegrationTestExtension.ALGOLIA_API_KEY_1;
-import static com.algolia.search.IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.DefaultSearchClient;
 import com.algolia.search.SearchClient;

--- a/algoliasearch-apache/src/test/java/com/algolia/search/insights/InsightsTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/insights/InsightsTest.java
@@ -1,5 +1,8 @@
 package com.algolia.search.insights;
 
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+
 import com.algolia.search.DefaultInsightsClient;
 import com.algolia.search.InsightsClient;
 import com.algolia.search.IntegrationTestExtension;
@@ -11,9 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class InsightsTest extends com.algolia.search.integration.insights.InsightsTest {
 
   private static InsightsClient insightsClient =
-      DefaultInsightsClient.create(
-          IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1,
-          IntegrationTestExtension.ALGOLIA_API_KEY_1);
+      DefaultInsightsClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
 
   InsightsTest() {
     super(IntegrationTestExtension.searchClient, insightsClient);

--- a/algoliasearch-apache/src/test/java/com/algolia/search/insights/InsightsTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/insights/InsightsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.insights;
 
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
 import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.DefaultInsightsClient;
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class InsightsTest extends com.algolia.search.integration.insights.InsightsTest {
 
   private static InsightsClient insightsClient =
-      DefaultInsightsClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+      DefaultInsightsClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1);
 
   InsightsTest() {
     super(IntegrationTestExtension.searchClient, insightsClient);

--- a/algoliasearch-apache/src/test/java/com/algolia/search/recommendation/RecommendationTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/recommendation/RecommendationTest.java
@@ -3,6 +3,7 @@ package com.algolia.search.recommendation;
 import com.algolia.search.DefaultRecommendationClient;
 import com.algolia.search.IntegrationTestExtension;
 import com.algolia.search.RecommendationClient;
+import com.algolia.search.integration.TestHelpers;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,9 +13,7 @@ class RecommendationTest extends com.algolia.search.integration.recommendation.R
 
   private static RecommendationClient recommendationClient =
       DefaultRecommendationClient.create(
-          IntegrationTestExtension.ALGOLIA_APPLICATION_ID_1,
-          IntegrationTestExtension.ALGOLIA_API_KEY_1,
-          "eu");
+          TestHelpers.ALGOLIA_APPLICATION_ID_1, TestHelpers.ALGOLIA_ADMIN_KEY_1, "eu");
 
   RecommendationTest() {
     super(recommendationClient);

--- a/algoliasearch-core-uber/pom.xml
+++ b/algoliasearch-core-uber/pom.xml
@@ -23,7 +23,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/algoliasearch-core/src/main/java/com/algolia/search/Defaults.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/Defaults.java
@@ -57,4 +57,6 @@ public class Defaults {
   static final String ALGOLIA_KEY_HEADER = "X-Algolia-API-Key";
   static final String ALGOLIA_USER_ID_HEADER = "X-Algolia-USER-ID";
   static final String USER_AGENT_HEADER = "User-Agent";
+  static final String CONTENT_TYPE_HEADER = "Content-Type";
+  static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/TestHelpers.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/TestHelpers.java
@@ -5,6 +5,15 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class TestHelpers {
+
+  public static String ALGOLIA_APPLICATION_ID_1 = System.getenv("ALGOLIA_APPLICATION_ID_1");
+  public static String ALGOLIA_API_KEY_1 = System.getenv("ALGOLIA_ADMIN_KEY_1");
+  public static String ALGOLIA_SEARCH_KEY_1 = System.getenv("ALGOLIA_SEARCH_KEY_1");
+  public static String ALGOLIA_APPLICATION_ID_2 = System.getenv("ALGOLIA_APPLICATION_ID_2");
+  public static String ALGOLIA_API_KEY_2 = System.getenv("ALGOLIA_ADMIN_KEY_2");
+  public static String ALGOLIA_APPLICATION_ID_MCM = System.getenv("ALGOLIA_APPLICATION_ID_MCM");
+  public static String ALGOLIA_ADMIN_KEY_MCM = System.getenv("ALGOLIA_ADMIN_KEY_MCM");
+
   public static String userName = System.getProperty("user.name");
   private static String osName = System.getProperty("os.name").trim();
   private static String javaVersion = System.getProperty("java.version");
@@ -18,5 +27,35 @@ public class TestHelpers {
     ZonedDateTime utc = ZonedDateTime.now(ZoneOffset.UTC);
     return String.format(
         "java-%s-%s", DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss").format(utc), userName);
+  }
+
+  public static void checkEnvironmentVariable() throws Exception {
+    if (ALGOLIA_APPLICATION_ID_1 == null || ALGOLIA_APPLICATION_ID_1.isEmpty()) {
+      throw new Exception("ALGOLIA_APPLICATION_ID is not defined or empty");
+    }
+
+    if (ALGOLIA_API_KEY_1 == null || ALGOLIA_API_KEY_1.isEmpty()) {
+      throw new Exception("ALGOLIA_API_KEY is not defined or empty");
+    }
+
+    if (ALGOLIA_SEARCH_KEY_1 == null || ALGOLIA_SEARCH_KEY_1.isEmpty()) {
+      throw new Exception("ALGOLIA_SEARCH_KEY_1 is not defined or empty");
+    }
+
+    if (ALGOLIA_APPLICATION_ID_2 == null || ALGOLIA_APPLICATION_ID_2.isEmpty()) {
+      throw new Exception("ALGOLIA_APPLICATION_ID_2 is not defined or empty");
+    }
+
+    if (ALGOLIA_API_KEY_2 == null || ALGOLIA_API_KEY_2.isEmpty()) {
+      throw new Exception("ALGOLIA_API_KEY_2 is not defined or empty");
+    }
+
+    if (ALGOLIA_APPLICATION_ID_MCM == null || ALGOLIA_APPLICATION_ID_MCM.isEmpty()) {
+      throw new Exception("ALGOLIA_APPLICATION_ID_MCM is not defined or empty");
+    }
+
+    if (ALGOLIA_ADMIN_KEY_MCM == null || ALGOLIA_ADMIN_KEY_MCM.isEmpty()) {
+      throw new Exception("ALGOLIA_ADMIN_KEY_MCM is not defined or empty");
+    }
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/TestHelpers.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/TestHelpers.java
@@ -7,10 +7,10 @@ import java.time.format.DateTimeFormatter;
 public class TestHelpers {
 
   public static String ALGOLIA_APPLICATION_ID_1 = System.getenv("ALGOLIA_APPLICATION_ID_1");
-  public static String ALGOLIA_API_KEY_1 = System.getenv("ALGOLIA_ADMIN_KEY_1");
+  public static String ALGOLIA_ADMIN_KEY_1 = System.getenv("ALGOLIA_ADMIN_KEY_1");
   public static String ALGOLIA_SEARCH_KEY_1 = System.getenv("ALGOLIA_SEARCH_KEY_1");
   public static String ALGOLIA_APPLICATION_ID_2 = System.getenv("ALGOLIA_APPLICATION_ID_2");
-  public static String ALGOLIA_API_KEY_2 = System.getenv("ALGOLIA_ADMIN_KEY_2");
+  public static String ALGOLIA_ADMIN_KEY_2 = System.getenv("ALGOLIA_ADMIN_KEY_2");
   public static String ALGOLIA_APPLICATION_ID_MCM = System.getenv("ALGOLIA_APPLICATION_ID_MCM");
   public static String ALGOLIA_ADMIN_KEY_MCM = System.getenv("ALGOLIA_ADMIN_KEY_MCM");
 
@@ -31,11 +31,11 @@ public class TestHelpers {
 
   public static void checkEnvironmentVariable() throws Exception {
     if (ALGOLIA_APPLICATION_ID_1 == null || ALGOLIA_APPLICATION_ID_1.isEmpty()) {
-      throw new Exception("ALGOLIA_APPLICATION_ID is not defined or empty");
+      throw new Exception("ALGOLIA_APPLICATION_ID_1 is not defined or empty");
     }
 
-    if (ALGOLIA_API_KEY_1 == null || ALGOLIA_API_KEY_1.isEmpty()) {
-      throw new Exception("ALGOLIA_API_KEY is not defined or empty");
+    if (ALGOLIA_ADMIN_KEY_1 == null || ALGOLIA_ADMIN_KEY_1.isEmpty()) {
+      throw new Exception("ALGOLIA_ADMIN_KEY_1 is not defined or empty");
     }
 
     if (ALGOLIA_SEARCH_KEY_1 == null || ALGOLIA_SEARCH_KEY_1.isEmpty()) {
@@ -46,8 +46,8 @@ public class TestHelpers {
       throw new Exception("ALGOLIA_APPLICATION_ID_2 is not defined or empty");
     }
 
-    if (ALGOLIA_API_KEY_2 == null || ALGOLIA_API_KEY_2.isEmpty()) {
-      throw new Exception("ALGOLIA_API_KEY_2 is not defined or empty");
+    if (ALGOLIA_ADMIN_KEY_2 == null || ALGOLIA_ADMIN_KEY_2.isEmpty()) {
+      throw new Exception("ALGOLIA_ADMIN_KEY_2 is not defined or empty");
     }
 
     if (ALGOLIA_APPLICATION_ID_MCM == null || ALGOLIA_APPLICATION_ID_MCM.isEmpty()) {

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/analytics/AnalyticsTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/analytics/AnalyticsTest.java
@@ -19,12 +19,10 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/client/MultiClusterManagementTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/client/MultiClusterManagementTest.java
@@ -7,14 +7,9 @@ import com.algolia.search.SearchClient;
 import com.algolia.search.exceptions.AlgoliaApiException;
 import com.algolia.search.models.indexing.SearchResult;
 import com.algolia.search.models.mcm.*;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public abstract class MultiClusterManagementTest {

--- a/algoliasearch-java-net/pom.xml
+++ b/algoliasearch-java-net/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>algoliasearch</artifactId>
         <groupId>com.algolia</groupId>
-        <version>3.6.2</version>
+        <version>3.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/algoliasearch-java-net/pom.xml
+++ b/algoliasearch-java-net/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>algoliasearch</artifactId>
+        <groupId>com.algolia</groupId>
+        <version>3.6.2</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>algoliasearch-java-net</artifactId>
+
+    <dependencies>
+        <!--Algolia dependencies-->
+        <dependency>
+            <groupId>com.algolia</groupId>
+            <artifactId>algoliasearch-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.algolia</groupId>
+            <artifactId>algoliasearch-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
@@ -1,0 +1,188 @@
+package com.algolia.search;
+
+import com.algolia.search.exceptions.AlgoliaRuntimeException;
+import com.algolia.search.models.HttpRequest;
+import com.algolia.search.models.HttpResponse;
+import com.algolia.search.util.HttpStatusCodeUtils;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ProxySelector;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.zip.GZIPInputStream;
+import javax.annotation.Nonnull;
+
+/** Implementation of {@code HttpRequester} for the built-in Java.net 11 HTTP Client */
+public final class JavaNetHttpRequester implements HttpRequester {
+
+  /** Reusable instance of the httpClient. */
+  private final HttpClient client;
+
+  /**
+   * Build the reusable instance of httpClient with the given configuration.
+   *
+   * @param config HTTPClient agnostic Algolia's configuration.
+   */
+  public JavaNetHttpRequester(@Nonnull ConfigBase config) {
+    client =
+        HttpClient.newBuilder()
+            .executor(config.getExecutor())
+            .version(HttpClient.Version.HTTP_2)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .proxy(ProxySelector.getDefault())
+            .connectTimeout(Duration.ofMillis(config.getConnectTimeOut()))
+            .build();
+  }
+
+  /**
+   * Sends the http request asynchronously to the API If the request is time out it creates a new
+   * response object with timeout set to true Otherwise it throws a run time exception
+   *
+   * @param request the request to send
+   * @throws AlgoliaRuntimeException When an error occurred processing the request on the server
+   *     side
+   */
+  public CompletableFuture<HttpResponse> performRequestAsync(@Nonnull HttpRequest request) {
+    return client
+        .sendAsync(buildRequest(request), BodyHandlers.ofInputStream())
+        .thenApply(this::buildResponse)
+        .exceptionally(
+            t -> {
+              if (t.getCause() instanceof HttpConnectTimeoutException
+                  || t.getCause() instanceof HttpTimeoutException) {
+                return new HttpResponse(true);
+              } else if (t.getCause() instanceof SecurityException
+                  || t.getCause() instanceof IOException
+                  || t.getCause() instanceof InterruptedException) {
+                return new HttpResponse().setNetworkError(true);
+              }
+              throw new AlgoliaRuntimeException(t);
+            });
+  }
+
+  /**
+   * Builds an Algolia response from the server response
+   *
+   * @param response The server response
+   */
+  private HttpResponse buildResponse(java.net.http.HttpResponse<InputStream> response) {
+    if (HttpStatusCodeUtils.isSuccess(response.statusCode())) {
+      return new HttpResponse(response.statusCode(), responseBodyHandler(response));
+    }
+
+    return new HttpResponse(response.statusCode(), convertStreamToString(response.body()));
+  }
+
+  /**
+   * Builds an http request from an AlgoliaRequest object
+   *
+   * @param algoliaRequest The Algolia request object
+   */
+  private java.net.http.HttpRequest buildRequest(@Nonnull HttpRequest algoliaRequest) {
+    java.net.http.HttpRequest.Builder builder = java.net.http.HttpRequest.newBuilder();
+
+    buildHeaders(builder, algoliaRequest.getHeaders());
+    buildURI(builder, algoliaRequest.getUri());
+    builder.timeout(Duration.ofMillis(algoliaRequest.getTimeout()));
+
+    BodyPublisher body = buildRequestBody(builder, algoliaRequest);
+    builder.method(algoliaRequest.getMethod().toString(), body);
+
+    return builder.build();
+  }
+
+  /**
+   * Build the body for the request builder. Handling compression type of the request.
+   *
+   * @param builder Request Builder
+   * @param algoliaRequest HttpClient agnostic Algolia's request
+   */
+  private BodyPublisher buildRequestBody(
+      @Nonnull Builder builder, @Nonnull HttpRequest algoliaRequest) {
+
+    if (algoliaRequest.getBody() == null) {
+      return java.net.http.HttpRequest.BodyPublishers.noBody();
+    }
+
+    if (algoliaRequest.canCompress()) {
+      builder.header(Defaults.CONTENT_ENCODING_HEADER, Defaults.CONTENT_ENCODING_GZIP);
+    } else {
+      builder.header(Defaults.CONTENT_TYPE_HEADER, Defaults.APPLICATION_JSON);
+    }
+
+    return BodyPublishers.ofInputStream(algoliaRequest::getBody);
+  }
+
+  /**
+   * Handles compressed response. Basically wraps the InputStream in a GZIPInputStream.
+   *
+   * @param response Server's response
+   */
+  private InputStream responseBodyHandler(java.net.http.HttpResponse<InputStream> response) {
+    String encoding = response.headers().firstValue(Defaults.CONTENT_ENCODING_HEADER).orElse("");
+    InputStream ret;
+
+    if (encoding.equals(Defaults.CONTENT_ENCODING_GZIP)) {
+      try {
+        ret = new GZIPInputStream(response.body());
+      } catch (IOException e) {
+        throw new AlgoliaRuntimeException(e);
+      }
+    } else {
+      ret = response.body();
+    }
+
+    return ret;
+  }
+
+  /**
+   * Builds a friendly URI Object for Java.net HTTP Client
+   *
+   * @param builder Request Builder
+   * @param url HttpClient agnostic Algolia's URL
+   */
+  private void buildURI(@Nonnull Builder builder, @Nonnull URL url) {
+    try {
+      builder.uri(url.toURI());
+    } catch (URISyntaxException e) {
+      throw new AlgoliaRuntimeException(e);
+    }
+  }
+
+  /**
+   * Builds a friendly Headers for Java's HTTPClient
+   *
+   * @param builder Request Builder
+   * @param headers HttpClient agnostic Algolia's headers
+   */
+  private void buildHeaders(@Nonnull Builder builder, @Nonnull Map<String, String> headers) {
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      builder.header(entry.getKey(), entry.getValue());
+    }
+  }
+
+  private String convertStreamToString(InputStream is) {
+    Scanner s = new Scanner(is, StandardCharsets.UTF_8).useDelimiter("\\A");
+    return s.hasNext() ? s.next() : "";
+  }
+
+  /** Nothing to do here. Java.net HTTP Client is not closeable. */
+  @Override
+  public void close() {
+    /*
+     Nothing to do here. Java 11 HTTP Client is not closeable.
+    */
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/IntegrationTestExtension.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/IntegrationTestExtension.java
@@ -14,11 +14,15 @@ public class IntegrationTestExtension implements BeforeAllCallback {
     TestHelpers.checkEnvironmentVariable();
 
     SearchConfig clientConfig =
-        new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1).build();
+        new SearchConfig.Builder(
+                TestHelpers.ALGOLIA_APPLICATION_ID_1, TestHelpers.ALGOLIA_ADMIN_KEY_1)
+            .build();
     searchClient = new SearchClient(clientConfig, new JavaNetHttpRequester(clientConfig));
 
     SearchConfig client2Config =
-        new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_2, ALGOLIA_ADMIN_KEY_2).build();
+        new SearchConfig.Builder(
+                TestHelpers.ALGOLIA_APPLICATION_ID_2, TestHelpers.ALGOLIA_ADMIN_KEY_2)
+            .build();
     searchClient2 = new SearchClient(client2Config, new JavaNetHttpRequester(client2Config));
   }
 }

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/IntegrationTestExtension.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/IntegrationTestExtension.java
@@ -1,0 +1,24 @@
+package com.algolia.search;
+
+import com.algolia.search.integration.TestHelpers;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class IntegrationTestExtension implements BeforeAllCallback {
+
+  public static SearchClient searchClient;
+  public static SearchClient searchClient2;
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    TestHelpers.checkEnvironmentVariable();
+
+    SearchConfig clientConfig =
+        new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1).build();
+    searchClient = new SearchClient(clientConfig, new JavaNetHttpRequester(clientConfig));
+
+    SearchConfig client2Config =
+        new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_2, ALGOLIA_ADMIN_KEY_2).build();
+    searchClient2 = new SearchClient(client2Config, new JavaNetHttpRequester(client2Config));
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/account/AccountCopyTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/account/AccountCopyTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.account;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class AccountCopyTest extends com.algolia.search.integration.account.AccountCopyTest {
+  AccountCopyTest() {
+    super(IntegrationTestExtension.searchClient, IntegrationTestExtension.searchClient2);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.analytics;
 
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
 import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.*;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class AnalyticsTest extends com.algolia.search.integration.analytics.AnalyticsTest {
 
   private static AnalyticsConfig analyticsConfig =
-      new AnalyticsConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1).build();
+      new AnalyticsConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1).build();
   private static AnalyticsClient analyticsClient =
       new AnalyticsClient(analyticsConfig, new JavaNetHttpRequester(analyticsConfig));
 

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/analytics/AnalyticsTest.java
@@ -1,0 +1,27 @@
+package com.algolia.search.analytics;
+
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+
+import com.algolia.search.*;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class AnalyticsTest extends com.algolia.search.integration.analytics.AnalyticsTest {
+
+  private static AnalyticsConfig analyticsConfig =
+      new AnalyticsConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1).build();
+  private static AnalyticsClient analyticsClient =
+      new AnalyticsClient(analyticsConfig, new JavaNetHttpRequester(analyticsConfig));
+
+  AnalyticsTest() {
+    super(IntegrationTestExtension.searchClient, analyticsClient);
+  }
+
+  @AfterAll
+  static void afterAll() throws IOException {
+    analyticsClient.close();
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/ApiKeysTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/ApiKeysTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.client;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class ApiKeysTest extends com.algolia.search.integration.client.ApiKeysTest {
+  ApiKeysTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/CopyIndexTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/CopyIndexTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.client;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class CopyIndexTest extends com.algolia.search.integration.client.CopyIndexTest {
+  CopyIndexTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/LogsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/LogsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.client;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class LogsTest extends com.algolia.search.integration.client.LogsTest {
+  LogsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/MultiClusterManagementTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/MultiClusterManagementTest.java
@@ -1,0 +1,25 @@
+package com.algolia.search.client;
+
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_MCM;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_MCM;
+
+import com.algolia.search.IntegrationTestExtension;
+import com.algolia.search.JavaNetHttpRequester;
+import com.algolia.search.SearchClient;
+import com.algolia.search.SearchConfig;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MultiClusterManagementTest
+    extends com.algolia.search.integration.client.MultiClusterManagementTest {
+
+  private static SearchConfig mcmConfig =
+      new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_MCM, ALGOLIA_ADMIN_KEY_MCM).build();
+
+  MultiClusterManagementTest() {
+
+    super(new SearchClient(mcmConfig, new JavaNetHttpRequester(mcmConfig)));
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/MultipleOperationsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/MultipleOperationsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.client;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class MultipleOperationsTest extends com.algolia.search.integration.client.MultipleOperationsTest {
+  MultipleOperationsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/SecuredAPIKeyTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/SecuredAPIKeyTest.java
@@ -1,0 +1,27 @@
+package com.algolia.search.client;
+
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_SEARCH_KEY_1;
+
+import com.algolia.search.IntegrationTestExtension;
+import com.algolia.search.JavaNetHttpRequester;
+import com.algolia.search.SearchClient;
+import com.algolia.search.SearchConfig;
+import com.algolia.search.models.apikeys.SecuredApiKeyRestriction;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SecuredAPIKeyTest extends com.algolia.search.integration.client.SecuredAPIKeyTest {
+
+  SecuredAPIKeyTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+
+  @Override
+  protected SearchClient createClientWithRestriction(SecuredApiKeyRestriction restriction)
+      throws Exception {
+    String key = searchClient.generateSecuredAPIKey(ALGOLIA_SEARCH_KEY_1, restriction);
+    SearchConfig restrictedConfig = new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, key).build();
+    return new SearchClient(restrictedConfig, new JavaNetHttpRequester(restrictedConfig));
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/TimeoutTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/TimeoutTest.java
@@ -1,0 +1,18 @@
+package com.algolia.search.client;
+
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+
+import com.algolia.search.JavaNetHttpRequester;
+import com.algolia.search.SearchClient;
+import com.algolia.search.SearchConfig;
+
+class TimeoutTest extends com.algolia.search.integration.client.TimeoutTest {
+  protected SearchConfig.Builder createBuilder() {
+    return new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+  }
+
+  protected SearchClient createClient(SearchConfig config) {
+    return new SearchClient(config, new JavaNetHttpRequester(config));
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/client/TimeoutTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/client/TimeoutTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.client;
 
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
 import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.JavaNetHttpRequester;
@@ -9,7 +9,7 @@ import com.algolia.search.SearchConfig;
 
 class TimeoutTest extends com.algolia.search.integration.client.TimeoutTest {
   protected SearchConfig.Builder createBuilder() {
-    return new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+    return new SearchConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1);
   }
 
   protected SearchClient createClient(SearchConfig config) {

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/BatchingTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/BatchingTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class BatchingTest extends com.algolia.search.integration.index.BatchingTest {
+  BatchingTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/ExistTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/ExistTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class ExistTest extends com.algolia.search.integration.index.ExistTest {
+  ExistTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/IndexingTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/IndexingTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class IndexingTest extends com.algolia.search.integration.index.IndexingTest {
+  IndexingTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/QueryRulesTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/QueryRulesTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class QueryRulesTest extends com.algolia.search.integration.index.QueryRulesTest {
+  QueryRulesTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/ReplacingTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/ReplacingTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class ReplacingTest extends com.algolia.search.integration.index.ReplacingTest {
+  ReplacingTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/SearchTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/SearchTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SearchTest extends com.algolia.search.integration.index.SearchTest {
+  SearchTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/SettingsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/SettingsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SettingsTest extends com.algolia.search.integration.index.SettingsTest {
+  SettingsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/index/SynonymsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/index/SynonymsTest.java
@@ -1,0 +1,11 @@
+package com.algolia.search.index;
+
+import com.algolia.search.IntegrationTestExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class SynonymsTest extends com.algolia.search.integration.index.SynonymsTest {
+  SynonymsTest() {
+    super(IntegrationTestExtension.searchClient);
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/insights/InsightsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/insights/InsightsTest.java
@@ -1,0 +1,23 @@
+package com.algolia.search.insights;
+
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+
+import com.algolia.search.InsightsClient;
+import com.algolia.search.InsightsConfig;
+import com.algolia.search.IntegrationTestExtension;
+import com.algolia.search.JavaNetHttpRequester;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({IntegrationTestExtension.class})
+class InsightsTest extends com.algolia.search.integration.insights.InsightsTest {
+
+  private static InsightsConfig config =
+      new InsightsConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1).build();
+
+  InsightsTest() {
+    super(
+        IntegrationTestExtension.searchClient,
+        new InsightsClient(config, new JavaNetHttpRequester(config)));
+  }
+}

--- a/algoliasearch-java-net/src/test/java/com/algolia/search/insights/InsightsTest.java
+++ b/algoliasearch-java-net/src/test/java/com/algolia/search/insights/InsightsTest.java
@@ -1,6 +1,6 @@
 package com.algolia.search.insights;
 
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_API_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
 import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 import com.algolia.search.InsightsClient;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class InsightsTest extends com.algolia.search.integration.insights.InsightsTest {
 
   private static InsightsConfig config =
-      new InsightsConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1).build();
+      new InsightsConfig.Builder(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1).build();
 
   InsightsTest() {
     super(

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <module>algoliasearch-core-uber</module>
         <module>algoliasearch-apache</module>
         <module>algoliasearch-apache-uber</module>
+        <module>algoliasearch-java-net</module>
     </modules>
 
     <licenses>
@@ -117,7 +118,10 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.1.1</version>
+                        <configuration>
+                            <source>1.8</source>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes

## Describe your change

The PR adds a new `algoliasearch-java-net` module which embeds the JDK11 http requester. This allow our JDK11 users to drop the dependency on Apache and to profit from HTTP2.

Adding a JDK11 module with other JDK8 modules require to update the `java-doc` plugin and to add `<source>1.8</source>` in its configuration, otherwise the build will fail. (Known issue on open JDK)

The CI is also updated: for JDK8; Travis will only run the test for the Apache module; for JDK11 it will test both `java-net` and `apache` modules.

## Review guidelines

Please review thoroughly the `java-net` requester
Please review thoroughly all pom.xml
