### PR TITLE
fix: AroundPrecision serialization in multipleQueries

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
@@ -1,8 +1,10 @@
 package com.algolia.search.util;
 
 import com.algolia.search.Defaults;
+import com.algolia.search.exceptions.AlgoliaRuntimeException;
 import com.algolia.search.models.apikeys.SecuredApiKeyRestriction;
 import com.algolia.search.models.indexing.SearchParameters;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -84,6 +86,17 @@ public class QueryStringUtils {
                               + "]";
 
                         } else {
+
+                          // Handling around precision special case
+                          if (e.getKey().equals("aroundPrecision")) {
+                            try {
+                              return Defaults.getObjectMapper().writeValueAsString(e.getValue());
+                            } catch (JsonProcessingException ex) {
+                              throw new AlgoliaRuntimeException(
+                                  "Error while serializing the request", ex);
+                            }
+                          }
+
                           // Handling List<?>
                           return String.join(",", (List) e.getValue());
                         }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -2,6 +2,7 @@ package com.algolia.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.models.indexing.AroundPrecision;
 import com.algolia.search.models.indexing.AroundRadius;
 import com.algolia.search.models.indexing.Query;
 import com.algolia.search.models.rules.*;
@@ -746,6 +747,16 @@ class JacksonParserTest {
 
     assertThat(query6.toParam())
         .isEqualTo("query=&insideBoundingBox=%5B%5B47.3165%2C4.9665%2C47.3424%2C5.0201%5D%5D");
+  }
+
+  @Test
+  void queryWithAroundPrecision() throws JsonProcessingException {
+    List<AroundPrecision> aroundPrecisionFar =
+        Arrays.asList(new AroundPrecision(0, 10000), new AroundPrecision(0, 100000));
+    Query query = new Query("barcelona").setAroundPrecision(aroundPrecisionFar);
+    assertThat(query.toParam())
+        .isEqualTo(
+            "aroundPrecision=%5B%7B%22from%22%3A0%2C%22value%22%3A10000%7D%2C%7B%22from%22%3A0%2C%22value%22%3A100000%7D%5D&query=barcelona");
   }
 
   @Test


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

using aroundPrecision in multipleQueries would cause:
`java.lang.ClassCastException: java.util.LinkedHashMap cannot be cast to java.lang.CharSequence`

The fix is a work-around to catch `aroundPrecision` in `toQueryParams`.