### PR TITLE
fix: add missing log type in getLogs

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/SearchClientAdvanced.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/SearchClientAdvanced.java
@@ -226,6 +226,7 @@ public interface SearchClientAdvanced extends SearchClientBase {
       requestOptions = new RequestOptions();
     }
 
+    requestOptions.addExtraQueryParameters("type", logType);
     requestOptions.addExtraQueryParameters("offset", Integer.toString(offset));
     requestOptions.addExtraQueryParameters("length", Integer.toString(length));
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/client/LogsTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/client/LogsTest.java
@@ -3,6 +3,7 @@ package com.algolia.search.integration.client;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.SearchClient;
+import com.algolia.search.models.common.LogType;
 import com.algolia.search.models.indexing.IndicesResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -23,7 +24,7 @@ public abstract class LogsTest {
 
     CompletableFuture.allOf(listIndices1, listIndices2).get();
     searchClient
-        .getLogsAsync(0, 2)
+        .getLogsAsync(0, 2, LogType.LOG_ALL.getName())
         .thenApply(
             r -> {
               assertThat(r).hasSize(2);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| BC breaks?        | no     
| Related Issue     | Fix #667 
| Need Doc update   | yes/no


## Describe your change

adds missing parameter `logType` in `getLogs`
