### PR TITLE
feat(build): apache-uber.jar: make it loadable as an OSGi bundle

### DIFF
--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -18,6 +18,27 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                    <id>bundle-manifest</id>
+                    <phase>process-classes</phase>
+                    <goals>
+                        <goal>manifest</goal>
+                    </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>4.2.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
By adding OSGi metadata to its manifest.

The generated (uber) jar can then be loaded in an OSGi platform. For example, it can be `installed` in Apache Felix. Note that to be "absolutely safe", we should include an (integration) test installing the generated jar in Felix along with an OSGi bundle leveraging the classes.