### PR TITLE
chore(compiler): explitly specify source and target versions

### DIFF
--- a/algoliasearch-java-net/pom.xml
+++ b/algoliasearch-java-net/pom.xml
@@ -9,19 +9,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
     <artifactId>algoliasearch-java-net</artifactId>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <!--Algolia dependencies-->

--- a/algoliasearch-java-net/pom.xml
+++ b/algoliasearch-java-net/pom.xml
@@ -10,6 +10,18 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>algoliasearch-java-net</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!--Algolia dependencies-->


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          |  no
| New feature?      | no   
| BC breaks?        | no     


## Describe your change

Explicitly specify source and target version of the `algoliasearch-java-net` module

## What problem is this fixing?

Remove warnings about the use of Java APIs available only since version 11