### PR TITLE
feat(logs): add inner_queries response field

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
@@ -1,18 +1,22 @@
 package com.algolia.search.models.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class InnerQuery implements Serializable {
 
+  @JsonProperty("index_name")
   private String indexName;
 
+  @JsonProperty("query_id")
   private String queryID;
 
   private Integer offset;
 
+  @JsonProperty("user_token")
   private String userToken;
 
   public String getIndexName() {

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
@@ -1,7 +1,6 @@
 package com.algolia.search.models.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -50,12 +49,19 @@ public class InnerQuery implements Serializable {
 
   @Override
   public String toString() {
-    return "InnerQuery{" +
-        "indexName='" + indexName + '\'' +
-        ", QueryID='" + queryID + '\'' +
-        ", offset=" + offset +
-        ", userToken='" + userToken + '\'' +
-        '}';
+    return "InnerQuery{"
+        + "indexName='"
+        + indexName
+        + '\''
+        + ", QueryID='"
+        + queryID
+        + '\''
+        + ", offset="
+        + offset
+        + ", userToken='"
+        + userToken
+        + '\''
+        + '}';
   }
 
   @Override

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
@@ -1,0 +1,73 @@
+package com.algolia.search.models.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class InnerQuery implements Serializable {
+
+  private String indexName;
+
+  private String queryID;
+
+  private Integer offset;
+
+  private String userToken;
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public void setIndexName(String indexName) {
+    this.indexName = indexName;
+  }
+
+  public String getQueryID() {
+    return queryID;
+  }
+
+  public void setQueryID(String queryID) {
+    this.queryID = queryID;
+  }
+
+  public Integer getOffset() {
+    return offset;
+  }
+
+  public void setOffset(Integer offset) {
+    this.offset = offset;
+  }
+
+  public String getUserToken() {
+    return userToken;
+  }
+
+  public void setUserToken(String userToken) {
+    this.userToken = userToken;
+  }
+
+  @Override
+  public String toString() {
+    return "InnerQuery{" +
+        "indexName='" + indexName + '\'' +
+        ", QueryID='" + queryID + '\'' +
+        ", offset=" + offset +
+        ", userToken='" + userToken + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    InnerQuery that = (InnerQuery) o;
+    return Objects.equals(queryID, that.queryID);
+  }
+
+  @Override
+  public int hashCode() {
+    return queryID != null ? queryID.hashCode() : 0;
+  }
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/InnerQuery.java
@@ -1,14 +1,20 @@
 package com.algolia.search.models.common;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class InnerQuery implements Serializable {
 
-  @JsonProperty("index_name")
+  @JsonCreator
+  public InnerQuery(@JsonProperty(value = "index_name") @Nonnull String indexName) {
+    this.indexName = indexName;
+  }
+
   private String indexName;
 
   @JsonProperty("query_id")
@@ -23,32 +29,36 @@ public class InnerQuery implements Serializable {
     return indexName;
   }
 
-  public void setIndexName(String indexName) {
+  public InnerQuery setIndexName(String indexName) {
     this.indexName = indexName;
+    return this;
   }
 
   public String getQueryID() {
     return queryID;
   }
 
-  public void setQueryID(String queryID) {
+  public InnerQuery setQueryID(String queryID) {
     this.queryID = queryID;
+    return this;
   }
 
   public Integer getOffset() {
     return offset;
   }
 
-  public void setOffset(Integer offset) {
+  public InnerQuery setOffset(Integer offset) {
     this.offset = offset;
+    return this;
   }
 
   public String getUserToken() {
     return userToken;
   }
 
-  public void setUserToken(String userToken) {
+  public InnerQuery setUserToken(String userToken) {
     this.userToken = userToken;
+    return this;
   }
 
   @Override

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/Log.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/Log.java
@@ -152,8 +152,9 @@ public class Log implements Serializable {
         + ", sha1='"
         + sha1
         + '\''
-        + ", innerQuery="
+        + ", innerQueries='"
         + innerQueries
+        + '\''
         + '}';
   }
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/Log.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/Log.java
@@ -3,7 +3,9 @@ package com.algolia.search.models.common;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.io.Serializable;
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -28,6 +30,9 @@ public class Log implements Serializable {
   private String queryHeaders;
 
   private String sha1;
+
+  @JsonProperty("inner_queries")
+  private List<InnerQuery> innerQueries;
 
   public String getTimestamp() {
     return timestamp;
@@ -70,6 +75,10 @@ public class Log implements Serializable {
     return this;
   }
 
+  public List<InnerQuery> getInnerQueries() {
+    return innerQueries;
+  }
+
   public Log setMethod(String method) {
     this.method = method;
     return this;
@@ -110,36 +119,23 @@ public class Log implements Serializable {
     return this;
   }
 
+  public void setInnerQueries(List<InnerQuery> innerQueries) {
+    this.innerQueries = innerQueries;
+  }
+
   @Override
   public String toString() {
-    return "Log{"
-        + "timestamp='"
-        + timestamp
-        + '\''
-        + ", method='"
-        + method
-        + '\''
-        + ", answerCode='"
-        + answerCode
-        + '\''
-        + ", queryBody='"
-        + queryBody
-        + '\''
-        + ", answer='"
-        + answer
-        + '\''
-        + ", url='"
-        + url
-        + '\''
-        + ", ip='"
-        + ip
-        + '\''
-        + ", queryHeaders='"
-        + queryHeaders
-        + '\''
-        + ", sha1='"
-        + sha1
-        + '\''
-        + '}';
+    return "Log{" +
+        "timestamp='" + timestamp + '\'' +
+        ", method='" + method + '\'' +
+        ", answerCode='" + answerCode + '\'' +
+        ", queryBody='" + queryBody + '\'' +
+        ", answer='" + answer + '\'' +
+        ", url='" + url + '\'' +
+        ", ip='" + ip + '\'' +
+        ", queryHeaders='" + queryHeaders + '\'' +
+        ", sha1='" + sha1 + '\'' +
+        ", innerQuery=" + innerQueries +
+        '}';
   }
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/common/Log.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/common/Log.java
@@ -3,7 +3,6 @@ package com.algolia.search.models.common;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.io.Serializable;
 import java.util.List;
 
@@ -125,17 +124,36 @@ public class Log implements Serializable {
 
   @Override
   public String toString() {
-    return "Log{" +
-        "timestamp='" + timestamp + '\'' +
-        ", method='" + method + '\'' +
-        ", answerCode='" + answerCode + '\'' +
-        ", queryBody='" + queryBody + '\'' +
-        ", answer='" + answer + '\'' +
-        ", url='" + url + '\'' +
-        ", ip='" + ip + '\'' +
-        ", queryHeaders='" + queryHeaders + '\'' +
-        ", sha1='" + sha1 + '\'' +
-        ", innerQuery=" + innerQueries +
-        '}';
+    return "Log{"
+        + "timestamp='"
+        + timestamp
+        + '\''
+        + ", method='"
+        + method
+        + '\''
+        + ", answerCode='"
+        + answerCode
+        + '\''
+        + ", queryBody='"
+        + queryBody
+        + '\''
+        + ", answer='"
+        + answer
+        + '\''
+        + ", url='"
+        + url
+        + '\''
+        + ", ip='"
+        + ip
+        + '\''
+        + ", queryHeaders='"
+        + queryHeaders
+        + '\''
+        + ", sha1='"
+        + sha1
+        + '\''
+        + ", innerQuery="
+        + innerQueries
+        + '}';
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -4,6 +4,7 @@ import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
 import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.algolia.search.models.common.InnerQuery;
 import com.algolia.search.models.indexing.AroundPrecision;
 import com.algolia.search.models.indexing.AroundRadius;
 import com.algolia.search.models.indexing.PartialUpdateOperation;
@@ -870,5 +871,20 @@ class JacksonParserTest {
     assertThat(serialized)
         .isEqualTo(
             "{\"objectID\":\"myID\",\"update\":{\"_operation\":\"Remove\",\"value\":\"something\"}}");
+  }
+
+  @Test
+  void innerQuery() throws IOException {
+    InnerQuery innerQuery =
+        new InnerQuery("index").setOffset(0).setUserToken("token").setQueryID("queryID");
+
+    String json = Defaults.getObjectMapper().writeValueAsString(innerQuery);
+    InnerQuery retrievedInnerQuery = Defaults.getObjectMapper().readValue(json, InnerQuery.class);
+
+    assertThat(json)
+        .isEqualTo(
+            "{\"indexName\":\"index\",\"offset\":0,\"query_id\":\"queryID\",\"user_token\":\"token\"}");
+
+    assertThat(retrievedInnerQuery.getIndexName()).isNotNull();
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      |yes 
| BC breaks?        | no     
| Related Issue     | Fix #686
| Need Doc update   | no


## Describe your change

add `innerQueries` response field in the `Log` response object