### PR TITLE
feat(build): make Apache Uber JAR OSGi-compliant

### DIFF
--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -19,6 +19,38 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>com.algolia.algoliasearch-apache-uber</Bundle-SymbolicName>
+                        <Bundle-Name>algoliasearch-apache-uber</Bundle-Name>
+                        <Export-Package>com.algolia.search</Export-Package>
+                        <Import-Package>javax.net.ssl,javax.naming,*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/example-osgi/README.md
+++ b/example-osgi/README.md
@@ -1,0 +1,94 @@
+# Using the Algolia Apache Uber JAR as an OSGi bundle
+
+## Step 1: Install an OSGi platform to run bundles
+
+Apache Karaf is an runner for OSGi bundles. It is the runner we use to test if
+our uber JARs are correctly bundled to run as OSGi bundles.
+
+To install Apache Karaf, go to https://karaf.apache.org/download.html and
+download the latest Binary distribution of the Karaf Runtime, as `.tar.gz` if
+you are using macOS or Linux or as `.zip` for Windows (not tested).
+
+Once downloaded and unarchived (`tar zxvf` to unarchive a `.tar.gz`), you can
+now go within the decompressed directory and run `bin/karaf`.
+
+By doing so, you start the Karaf Runtime which lets you install, start, remove
+OSGi bundles. Those bundles actually are plain JARs with some extra entries
+within their `MANIFEST.MF` file.
+
+The main commands are:
+
+ - `bundle:list` to list installed bundles with their associated unique IDs
+ - `bundle:install mvn:com.algolia/algoliasearch-apache-uber/3.9.0` to install a Maven bundle
+ - `bundle:start <ID>` to start an installed bundle
+ - `bundle:uninstall <ID>` to uninstall a bundle
+ - `log:display` to debug or investigate the most recent logs
+
+## Step 2: Build the Algolia bundle locally
+
+To make the Algolia bundle visible to Apache Karaf when we will want to install
+it, we need to create the usual JAR package and install it in our local
+M2 repository (under `~/.m2/`). This can be done with the following
+`mvn install` command, performed from the root of the Algolia Java library:
+
+```sh
+mvn clean install -DskipTests -pl algoliasearch-apache,algoliasearch-apache-uber
+```
+
+## Step 3: Build the Algolia OSGi Demo Bundle
+
+Same thing as before. This time, we are building a demo bundle application,
+which has an entry point, called a `BundleActivator`, which depends on the
+Algolia Apache uber JAR and we install it in our local M2 repository as well.
+
+```sh
+cd example-osgi
+mvn clean install
+```
+
+## Step 4: Install and start the bundles
+
+Go back to your Apache Karaf interactive prompt we have set up in Step 1 and
+use the following commands:
+
+```sh
+bundle:install mvn:com.algolia/algoliasearch-apache-uber/3.9.0
+bundle:install mvn:com.algolia/example-osgi/3.9.0
+```
+
+Then perform a `bundle:list` to ensure the two bundles are not listed and are
+in `Installed` state, such as:
+
+```sh
+karaf@root()> bundle:install mvn:com.algolia/algoliasearch-apache-uber/3.9.0
+Bundle ID: 44
+karaf@root()> bundle:install mvn:com.algolia/example-osgi/3.9.0
+Bundle ID: 45
+karaf@root()> bundle:list
+START LEVEL 100 , List Threshold: 50
+ID │ State     │ Lvl │ Version │ Name
+───┼───────────┼─────┼─────────┼────────────────────────────────────────
+22 │ Active    │  80 │ 4.2.8   │ Apache Karaf :: OSGi Services :: Event
+44 │ Installed │  80 │ 3.9.0   │ algoliasearch-apache-uber
+45 │ Installed │  80 │ 3.9.0   │ example-osgi
+karaf@root()>
+```
+
+You should then be able to start the bundles, first the Algolia Java uber JAR
+then the Demo Bundle which performs a `client.listIndices()`:
+
+```sh
+karaf@root()> bundle:start 44
+karaf@root()> bundle:start 45
+Algolia Demo Bundle is starting (listIndices() listed 7993 indices)
+```
+
+## References
+
+- https://github.com/algolia/algoliasearch-client-java-2/pull/697/files
+- https://karaf.apache.org/manual/latest/#_directory_structure
+- https://michaelrice.com/2015/04/the-simplest-osgi-karaf-hello-world-demo-i-could-come-up-with/
+- https://www.baeldung.com/osgi
+- https://stackoverflow.com/questions/8352710/osgi-missing-requirement-error
+- https://github.com/Dynatrace/Dynatrace-AppMon-Server-REST-Java-SDK/issues/1
+- https://www.javaworld.com/article/2077837/java-se-hello-osgi-part-1-bundles-for-beginners.html?page=3

--- a/example-osgi/pom.xml
+++ b/example-osgi/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.algolia</groupId>
+    <artifactId>example-osgi</artifactId>
+    <version>3.9.0</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>com.algolia.example-osgi</Bundle-SymbolicName>
+                        <Bundle-Name>example-osgi</Bundle-Name>
+                        <Bundle-Activator>com.algolia.example.osgi.DemoBundle</Bundle-Activator>
+                        <Export-Package>com.algolia.example.osgi</Export-Package>
+                        <Import-Package>com.algolia.search,org.osgi.framework,*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.algolia</groupId>
+            <artifactId>algoliasearch-apache-uber</artifactId>
+            <version>3.9.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/example-osgi/src/main/java/com/algolia/example/osgi/DemoBundle.java
+++ b/example-osgi/src/main/java/com/algolia/example/osgi/DemoBundle.java
@@ -1,0 +1,25 @@
+package com.algolia.example.osgi;
+
+import com.algolia.search.DefaultSearchClient;
+import com.algolia.search.SearchClient;
+import com.algolia.search.models.indexing.IndicesResponse;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+import java.util.List;
+
+public class DemoBundle implements BundleActivator {
+    @Override
+    public void start(BundleContext bundleContext) throws Exception {
+        String appID = System.getenv("ALGOLIA_APPLICATION_ID_1");
+        String apiKey = System.getenv("ALGOLIA_ADMIN_KEY_1");
+        SearchClient client = DefaultSearchClient.create(appID, apiKey);
+        List<IndicesResponse> indices = client.listIndices();
+        System.out.printf("Algolia Demo Bundle is starting (listIndices() listed %d indices)\n", indices.size());
+    }
+
+    @Override
+    public void stop(BundleContext bundleContext) throws Exception {
+        System.out.println("Algolia Demo Bundle is stopping.");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
 
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.5.1</version>
                         <configuration>
@@ -91,8 +92,9 @@
                         <version>2.7</version>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
-                        <version>2.4</version>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -244,6 +246,11 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>4.2.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Following the requests made by some recent users, this commit changes
the `pom.xml` configuration of our `algoliasearch-apache-uber` module in
order to make it installable as a valid OSGi bundle.

To ensure this works, we have created a new `example-osgi` directory.
This project is a "Hello World"-like OSGi bundle application which
depends on the `algoliasearch-apache-uber` module at runtime. It
contains both the code and a detailled `README.md` on how to install,
build and deploy such application from scratch, using the Apache Karaf
OSGi-application runner.