### PR TITLE
feat(rules): expose rule.consequence.promote.objectIDs string array

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequencePromote.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequencePromote.java
@@ -1,7 +1,9 @@
 package com.algolia.search.models.rules;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Consequence parameter. More information:
@@ -9,20 +11,9 @@ import java.io.Serializable;
  * @see <a href="https://www.algolia.com/doc/api-client/methods/query-rules">Algolia.com</a>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ConsequencePromote implements Serializable {
-  private String objectID;
+public abstract class ConsequencePromote implements Serializable {
+
   private Integer position;
-
-  public ConsequencePromote() {}
-
-  public String getObjectID() {
-    return objectID;
-  }
-
-  public ConsequencePromote setObjectID(String objectID) {
-    this.objectID = objectID;
-    return this;
-  }
 
   public Integer getPosition() {
     return position;
@@ -31,5 +22,33 @@ public class ConsequencePromote implements Serializable {
   public ConsequencePromote setPosition(Integer position) {
     this.position = position;
     return this;
+  }
+
+  public static class Single extends ConsequencePromote {
+
+    private String objectID;
+
+    public String getObjectID() {
+      return objectID;
+    }
+
+    public Single setObjectID(String objectID) {
+      this.objectID = objectID;
+      return this;
+    }
+  }
+
+  public static class Multiple extends ConsequencePromote {
+
+    private List<String> objectIDs;
+
+    public List<String> getObjectIDs() {
+      return objectIDs;
+    }
+
+    public Multiple setObjectID(List<String> objectIDs) {
+      this.objectIDs = objectIDs;
+      return this;
+    }
   }
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequencePromote.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequencePromote.java
@@ -1,18 +1,6 @@
 package com.algolia.search.models.rules;
 
-import static com.algolia.search.models.rules.ConsequencePromote.*;
-
-import com.algolia.search.exceptions.AlgoliaRuntimeException;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 
@@ -21,25 +9,22 @@ import java.util.List;
  *
  * @see <a href="https://www.algolia.com/doc/api-client/methods/query-rules">Algolia.com</a>
  */
-@JsonSerialize(using = ConsequencePromoteSerializer.class)
-@JsonDeserialize(using = ConsequencePromoteDeserializer.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public abstract class ConsequencePromote implements Serializable {
-
-  static final String KEY_POSITION = "position";
-  static final String KEY_OBJECT_ID = "objectID";
-  static final String KEY_OBJECT_IDS = "objectIDs";
-
-  public static ConsequencePromote of(String objectID, Integer position) {
-    return new Single().setObjectID(objectID).setPosition(position);
-  }
-
-  public static ConsequencePromote of(List<String> objectIDs, Integer position) {
-    return new Multiple().setObjectID(objectIDs).setPosition(position);
-  }
-
-  @JsonProperty(KEY_POSITION)
+public class ConsequencePromote implements Serializable {
+  private String objectID;
   private Integer position;
+  private List<String> objectIDs;
+
+  public ConsequencePromote() {}
+
+  public String getObjectID() {
+    return objectID;
+  }
+
+  public ConsequencePromote setObjectID(String objectID) {
+    this.objectID = objectID;
+    return this;
+  }
 
   public Integer getPosition() {
     return position;
@@ -50,87 +35,12 @@ public abstract class ConsequencePromote implements Serializable {
     return this;
   }
 
-  public static class Single extends ConsequencePromote {
-
-    @JsonProperty(KEY_OBJECT_ID)
-    private String objectID;
-
-    public String getObjectID() {
-      return objectID;
-    }
-
-    public Single setObjectID(String objectID) {
-      this.objectID = objectID;
-      return this;
-    }
-
-    @Override
-    public Single setPosition(Integer position) {
-      super.setPosition(position);
-      return this;
-    }
+  public List<String> getObjectIDs() {
+    return objectIDs;
   }
 
-  public static class Multiple extends ConsequencePromote {
-
-    @JsonProperty(KEY_OBJECT_IDS)
-    private List<String> objectIDs;
-
-    public List<String> getObjectIDs() {
-      return objectIDs;
-    }
-
-    public Multiple setObjectID(List<String> objectIDs) {
-      this.objectIDs = objectIDs;
-      return this;
-    }
-
-    @Override
-    public Multiple setPosition(Integer position) {
-      super.setPosition(position);
-      return this;
-    }
-  }
-}
-
-class ConsequencePromoteSerializer extends JsonSerializer<ConsequencePromote> {
-
-  @Override
-  public void serialize(ConsequencePromote value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
-    gen.writeStartObject();
-    gen.writeObjectField(KEY_POSITION, value.getPosition());
-    if (value instanceof ConsequencePromote.Single) {
-      ConsequencePromote.Single promote = (ConsequencePromote.Single) value;
-      gen.writeObjectField(KEY_OBJECT_ID, promote.getObjectID());
-    } else if (value instanceof ConsequencePromote.Multiple) {
-      ConsequencePromote.Multiple promote = (ConsequencePromote.Multiple) value;
-      gen.writeObjectField(KEY_OBJECT_IDS, promote.getObjectIDs());
-    }
-    gen.writeEndObject();
-  }
-}
-
-class ConsequencePromoteDeserializer extends JsonDeserializer<ConsequencePromote> {
-
-  @Override
-  public ConsequencePromote deserialize(JsonParser p, DeserializationContext ctxt)
-      throws IOException {
-    ObjectMapper objectMapper = (ObjectMapper) p.getCodec();
-    ObjectNode object = objectMapper.readTree(p);
-    int position = object.get(KEY_POSITION).asInt();
-
-    if (object.has(KEY_OBJECT_ID)) {
-      String objectID = object.get(KEY_OBJECT_ID).asText();
-      return ConsequencePromote.of(objectID, position);
-    } else if (object.has(KEY_OBJECT_IDS)) {
-      JsonNode node = object.get(KEY_OBJECT_IDS);
-      TypeReference<List<String>> type = new TypeReference<List<String>>() {};
-      List<String> objectIDs = objectMapper.readerFor(type).readValue(node);
-      return ConsequencePromote.of(objectIDs, position);
-    } else {
-      throw new AlgoliaRuntimeException(
-          "Unexpected JSON format occurred during the deserialization of promote rules");
-    }
+  public ConsequencePromote setObjectIDs(List<String> objectIDs) {
+    this.objectIDs = objectIDs;
+    return this;
   }
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequencePromote.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequencePromote.java
@@ -1,7 +1,18 @@
 package com.algolia.search.models.rules;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import static com.algolia.search.models.rules.ConsequencePromote.*;
 
+import com.algolia.search.exceptions.AlgoliaRuntimeException;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 
@@ -10,9 +21,24 @@ import java.util.List;
  *
  * @see <a href="https://www.algolia.com/doc/api-client/methods/query-rules">Algolia.com</a>
  */
+@JsonSerialize(using = ConsequencePromoteSerializer.class)
+@JsonDeserialize(using = ConsequencePromoteDeserializer.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class ConsequencePromote implements Serializable {
 
+  static final String KEY_POSITION = "position";
+  static final String KEY_OBJECT_ID = "objectID";
+  static final String KEY_OBJECT_IDS = "objectIDs";
+
+  public static ConsequencePromote of(String objectID, Integer position) {
+    return new Single().setObjectID(objectID).setPosition(position);
+  }
+
+  public static ConsequencePromote of(List<String> objectIDs, Integer position) {
+    return new Multiple().setObjectID(objectIDs).setPosition(position);
+  }
+
+  @JsonProperty(KEY_POSITION)
   private Integer position;
 
   public Integer getPosition() {
@@ -26,6 +52,7 @@ public abstract class ConsequencePromote implements Serializable {
 
   public static class Single extends ConsequencePromote {
 
+    @JsonProperty(KEY_OBJECT_ID)
     private String objectID;
 
     public String getObjectID() {
@@ -36,10 +63,17 @@ public abstract class ConsequencePromote implements Serializable {
       this.objectID = objectID;
       return this;
     }
+
+    @Override
+    public Single setPosition(Integer position) {
+      super.setPosition(position);
+      return this;
+    }
   }
 
   public static class Multiple extends ConsequencePromote {
 
+    @JsonProperty(KEY_OBJECT_IDS)
     private List<String> objectIDs;
 
     public List<String> getObjectIDs() {
@@ -49,6 +83,54 @@ public abstract class ConsequencePromote implements Serializable {
     public Multiple setObjectID(List<String> objectIDs) {
       this.objectIDs = objectIDs;
       return this;
+    }
+
+    @Override
+    public Multiple setPosition(Integer position) {
+      super.setPosition(position);
+      return this;
+    }
+  }
+}
+
+class ConsequencePromoteSerializer extends JsonSerializer<ConsequencePromote> {
+
+  @Override
+  public void serialize(ConsequencePromote value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeStartObject();
+    gen.writeObjectField(KEY_POSITION, value.getPosition());
+    if (value instanceof ConsequencePromote.Single) {
+      ConsequencePromote.Single promote = (ConsequencePromote.Single) value;
+      gen.writeObjectField(KEY_OBJECT_ID, promote.getObjectID());
+    } else if (value instanceof ConsequencePromote.Multiple) {
+      ConsequencePromote.Multiple promote = (ConsequencePromote.Multiple) value;
+      gen.writeObjectField(KEY_OBJECT_IDS, promote.getObjectIDs());
+    }
+    gen.writeEndObject();
+  }
+}
+
+class ConsequencePromoteDeserializer extends JsonDeserializer<ConsequencePromote> {
+
+  @Override
+  public ConsequencePromote deserialize(JsonParser p, DeserializationContext ctxt)
+      throws IOException {
+    ObjectMapper objectMapper = (ObjectMapper) p.getCodec();
+    ObjectNode object = objectMapper.readTree(p);
+    int position = object.get(KEY_POSITION).asInt();
+
+    if (object.has(KEY_OBJECT_ID)) {
+      String objectID = object.get(KEY_OBJECT_ID).asText();
+      return ConsequencePromote.of(objectID, position);
+    } else if (object.has(KEY_OBJECT_IDS)) {
+      JsonNode node = object.get(KEY_OBJECT_IDS);
+      TypeReference<List<String>> type = new TypeReference<List<String>>() {};
+      List<String> objectIDs = objectMapper.readerFor(type).readValue(node);
+      return ConsequencePromote.of(objectIDs, position);
+    } else {
+      throw new AlgoliaRuntimeException(
+          "Unexpected JSON format occurred during the deserialization of promote rules");
     }
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -937,16 +937,19 @@ class JacksonParserTest {
         new Consequence()
             .setPromote(
                 Arrays.asList(
-                    ConsequencePromote.of("a", 0),
-                    ConsequencePromote.of(Arrays.asList("b", "c"), 1)));
+                    new ConsequencePromote().setObjectID("a").setPosition(0),
+                    new ConsequencePromote().setObjectIDs(Arrays.asList("b", "c")).setPosition(1)));
 
     String json = Defaults.getObjectMapper().writeValueAsString(consequence);
     Consequence retrieveConsequence = Defaults.getObjectMapper().readValue(json, Consequence.class);
-
     List<ConsequencePromote> promote = retrieveConsequence.getPromote();
+
     assertThat(promote).hasSize(2);
-    assertThat(promote.get(0)).isInstanceOf(ConsequencePromote.Single.class);
-    assertThat(promote.get(1)).isInstanceOf(ConsequencePromote.Multiple.class);
-    assertThat(((ConsequencePromote.Multiple) promote.get(1)).getObjectIDs()).hasSize(2);
+    // Single ObjectID case
+    assertThat(promote.get(0).getObjectID()).isEqualTo("a");
+    assertThat(promote.get(0).getObjectIDs()).isNull();
+    // Multiple ObjectIDs case
+    assertThat(promote.get(1).getObjectID()).isNull();
+    assertThat(promote.get(1).getObjectIDs()).isEqualTo(Arrays.asList("b", "c"));
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -15,6 +15,7 @@ import com.algolia.search.models.rules.AutomaticFacetFilter;
 import com.algolia.search.models.rules.Condition;
 import com.algolia.search.models.rules.Consequence;
 import com.algolia.search.models.rules.ConsequenceParams;
+import com.algolia.search.models.rules.ConsequencePromote;
 import com.algolia.search.models.rules.ConsequenceQuery;
 import com.algolia.search.models.rules.Edit;
 import com.algolia.search.models.rules.EditType;
@@ -261,7 +262,6 @@ class JacksonParserTest {
         new Rule()
             .setConsequence(
                 new Consequence()
-                    .setPromote(Arrays.asList(new ConsequencePromote.Single()))
                     .setParams(
                         new ConsequenceParams()
                             .setOptionalFilters(
@@ -929,5 +929,24 @@ class JacksonParserTest {
     String typeList = "{\"type\":[\"type1\",\"type2\"]}";
     Alternative altList = Defaults.getObjectMapper().readValue(typeList, Alternative.class);
     assertThat(altList.getType()).isEqualTo("type1,type2");
+  }
+
+  @Test
+  void testConsequencePromotion() throws IOException {
+    Consequence consequence =
+        new Consequence()
+            .setPromote(
+                Arrays.asList(
+                    ConsequencePromote.of("a", 0),
+                    ConsequencePromote.of(Arrays.asList("b", "c"), 1)));
+
+    String json = Defaults.getObjectMapper().writeValueAsString(consequence);
+    Consequence retrieveConsequence = Defaults.getObjectMapper().readValue(json, Consequence.class);
+
+    List<ConsequencePromote> promote = retrieveConsequence.getPromote();
+    assertThat(promote).hasSize(2);
+    assertThat(promote.get(0)).isInstanceOf(ConsequencePromote.Single.class);
+    assertThat(promote.get(1)).isInstanceOf(ConsequencePromote.Multiple.class);
+    assertThat(((ConsequencePromote.Multiple) promote.get(1)).getObjectIDs()).hasSize(2);
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -261,6 +261,7 @@ class JacksonParserTest {
         new Rule()
             .setConsequence(
                 new Consequence()
+                    .setPromote(Arrays.asList(new ConsequencePromote.Single()))
                     .setParams(
                         new ConsequenceParams()
                             .setOptionalFilters(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes 
| BC breaks?        | yes     
| Related Issue     | Fix #694
| Need Doc update   | yes


## Describe your change

Add support of the new field `objectIDs`.
The  tricky part here is to make this a discriminate union and not just make objectID & objectIDs optional, one of both needs to be set.

Note: a less aggressive change can be to simply add a new property with checks and logic operations in the setters, but this can be error-prone IMO.
