### PR TITLE
fix(search): add support of quoted booleans in IgnorePlurals

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/settings/IgnorePlurals.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/settings/IgnorePlurals.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.NumberDeserializers.BooleanDeserializer;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
@@ -98,7 +99,8 @@ class IgnorePluralsDeserializer extends JsonDeserializer<IgnorePlurals> {
       return IgnorePlurals.of(languages);
     }
 
-    return IgnorePlurals.of(p.getBooleanValue());
+    BooleanDeserializer booleanDeserializer = new BooleanDeserializer(Boolean.TYPE, Boolean.FALSE);
+    return IgnorePlurals.of(booleanDeserializer.deserialize(p, ctxt));
   }
 }
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -128,6 +128,12 @@ class JacksonParserTest {
 
     ignorePlurals =
         Defaults.getObjectMapper()
+            .readValue("{\"ignorePlurals\":\"true\"}", IndexSettings.class)
+            .getIgnorePlurals();
+    assertThat(ignorePlurals).isEqualTo(IgnorePlurals.of(true));
+
+    ignorePlurals =
+        Defaults.getObjectMapper()
             .readValue("{\"ignorePlurals\":[\"en\"]}", IndexSettings.class)
             .getIgnorePlurals();
     assertThat(ignorePlurals).isEqualTo(IgnorePlurals.of(Collections.singletonList("en")));


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #695
| Need Doc update   | no


## Describe your change

Add support of quoted booleans in `IgnorePlurals`
