### PR TITLE
fix(explain): add support of `type` property as a List in `Alternative`

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Alternative.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/Alternative.java
@@ -1,5 +1,6 @@
 package com.algolia.search.models.indexing;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 public class Alternative {
@@ -48,7 +49,9 @@ public class Alternative {
     return this;
   }
 
+  @JsonDeserialize(using = FlatListDeserializer.class)
   private String type;
+
   private List<String> words;
   private Long typos;
   private Long offset;

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FlatListDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FlatListDeserializer.java
@@ -1,0 +1,31 @@
+package com.algolia.search.models.indexing;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+import java.util.List;
+
+public class FlatListDeserializer extends StdDeserializer<String> {
+
+  public FlatListDeserializer() {
+    this(null);
+  }
+
+  private FlatListDeserializer(Class<List<String>> t) {
+    super(t);
+  }
+
+  @Override
+  public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    if (p.isExpectedStartArrayToken()) {
+      ObjectMapper mapper = (ObjectMapper) p.getCodec();
+      List<String> list = mapper.readValue(p, new TypeReference<List<String>>() {});
+      return String.join(",", list);
+    }
+
+    return p.getText();
+  }
+}

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -5,16 +5,33 @@ import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.algolia.search.models.common.InnerQuery;
+import com.algolia.search.models.indexing.Alternative;
 import com.algolia.search.models.indexing.AroundPrecision;
 import com.algolia.search.models.indexing.AroundRadius;
 import com.algolia.search.models.indexing.PartialUpdateOperation;
 import com.algolia.search.models.indexing.Query;
-import com.algolia.search.models.rules.*;
-import com.algolia.search.models.settings.*;
+import com.algolia.search.models.rules.Alternatives;
+import com.algolia.search.models.rules.AutomaticFacetFilter;
+import com.algolia.search.models.rules.Condition;
+import com.algolia.search.models.rules.Consequence;
+import com.algolia.search.models.rules.ConsequenceParams;
+import com.algolia.search.models.rules.ConsequenceQuery;
+import com.algolia.search.models.rules.Edit;
+import com.algolia.search.models.rules.EditType;
+import com.algolia.search.models.rules.Rule;
+import com.algolia.search.models.settings.Distinct;
+import com.algolia.search.models.settings.IgnorePlurals;
+import com.algolia.search.models.settings.IndexSettings;
+import com.algolia.search.models.settings.RemoveStopWords;
+import com.algolia.search.models.settings.TypoTolerance;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -894,5 +911,16 @@ class JacksonParserTest {
     IndexSettings result = serializeDeserialize(settings);
     assertThat(result).isEqualToComparingFieldByField(settings);
     assertThat(result.getEnablePersonalization()).isEqualTo(true);
+  }
+
+  @Test
+  void alternativeType() throws IOException {
+    String typeString = "{\"type\":\"type1,type2\"}";
+    Alternative altString = Defaults.getObjectMapper().readValue(typeString, Alternative.class);
+    assertThat(altString.getType()).isEqualTo("type1,type2");
+
+    String typeList = "{\"type\":[\"type1\",\"type2\"]}";
+    Alternative altList = Defaults.getObjectMapper().readValue(typeList, Alternative.class);
+    assertThat(altList.getType()).isEqualTo("type1,type2");
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #656
| Need Doc update   | no


## Describe your change

Add a custum deserialization for the `type` property in the Explain.Alternative object.