### PR TITLE
chore(algoliasearch-core): upgrade Jackson dependencies from 2.9 (2019) to 2.11 (2020)

### DIFF
--- a/algoliasearch-core/pom.xml
+++ b/algoliasearch-core/pom.xml
@@ -11,8 +11,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jackson-databind.version>2.9.10.4</jackson-databind.version>
-        <jackson.version>2.9.10</jackson.version>
+        <jackson.version>2.11.0</jackson.version>
+        <jackson-databind.version>2.11.0</jackson-databind.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This change is introduced to resolve the `jackson-databind` security
vulnerabilities reported by dependabot as of 2.9.10.4 and lower.