### PR TITLE
feat(indexing): add 'IncrementFrom' and 'IncrementSet' operations

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/PartialUpdateOperation.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/PartialUpdateOperation.java
@@ -35,6 +35,14 @@ public class PartialUpdateOperation<T> {
     return new PartialUpdateOperation<>(PartialUpdateOperationType.INCREMENT, value);
   }
 
+  public static PartialUpdateOperation<Integer> incrementFrom(Integer value) {
+    return new PartialUpdateOperation<>(PartialUpdateOperationType.INCREMENT_FROM, value);
+  }
+
+  public static PartialUpdateOperation<Integer> incrementSet(Integer value) {
+    return new PartialUpdateOperation<>(PartialUpdateOperationType.INCREMENT_SET, value);
+  }
+
   public static PartialUpdateOperation<Integer> decrement(Integer value) {
     return new PartialUpdateOperation<>(PartialUpdateOperationType.DECREMENT, value);
   }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/PartialUpdateOperationType.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/PartialUpdateOperationType.java
@@ -2,6 +2,8 @@ package com.algolia.search.models.indexing;
 
 public class PartialUpdateOperationType {
   public static final String INCREMENT = "Increment";
+  public static final String INCREMENT_FROM = "IncrementFrom";
+  public static final String INCREMENT_SET = "IncrementSet";
   public static final String DECREMENT = "Decrement";
   public static final String ADD = "Add";
   public static final String ADD_UNIQUE = "AddUnique";

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -854,6 +854,28 @@ class JacksonParserTest {
   }
 
   @Test
+  void partialUpdateOperation_increment_from() throws JsonProcessingException {
+    RecordWithPartialUpdate record = new RecordWithPartialUpdate();
+    record.setObjectID("myID");
+    record.setUpdate(PartialUpdateOperation.incrementFrom(2));
+    String serialized = Defaults.getObjectMapper().writeValueAsString(record);
+    assertThat(serialized)
+        .isEqualTo(
+            "{\"objectID\":\"myID\",\"update\":{\"_operation\":\"IncrementFrom\",\"value\":2}}");
+  }
+
+  @Test
+  void partialUpdateOperation_increment_set() throws JsonProcessingException {
+    RecordWithPartialUpdate record = new RecordWithPartialUpdate();
+    record.setObjectID("myID");
+    record.setUpdate(PartialUpdateOperation.incrementSet(2));
+    String serialized = Defaults.getObjectMapper().writeValueAsString(record);
+    assertThat(serialized)
+        .isEqualTo(
+            "{\"objectID\":\"myID\",\"update\":{\"_operation\":\"IncrementSet\",\"value\":2}}");
+  }
+
+  @Test
   void partialUpdateOperation_decrement() throws JsonProcessingException {
     RecordWithPartialUpdate record = new RecordWithPartialUpdate();
     record.setObjectID("myID");


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes 
| BC breaks?        | yes     
| Related Issue     | Fix #710
| Need Doc update   | yes


## Describe your change

The built-in operations `IncrementFrom` and `IncrementSet`guarantee that the update will be idempotent, as those operations will force the update to be rejected if applied more than once.