### PR TITLE
chore(ci): make CircleCI perform the `mvn deploy` step upon tagged commit on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,24 @@ jobs:
           paths:
             - "~/.m2"
 
+  release:
+    docker:
+      - image: circleci/openjdk:11-jdk
+    steps:
+      - checkout
+      - restore_cache:
+          key: mvn-cache-11
+      - run:
+          name: Release new version
+          command: |
+            if [[ -z "$BINTRAY_USER" ]];    then echo '$BINTRAY_USER is not set';     exit 1; fi
+            if [[ -z "$BINTRAY_API_KEY" ]]; then echo '$BINTRAY_API_KEY is not set';  exit 1; fi
+            mvn -s .circleci/settings.xml deploy -DskipTests
+      - save_cache:
+          key: mvn-cache-11
+          paths:
+            - "~/.m2"
+
 workflows:
   version: 2
   build:
@@ -68,3 +86,13 @@ workflows:
       - format
       - test-java-8
       - test-java-11
+      - release:
+          requires:
+            - format
+            - test-java-8
+            - test-java-11
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^[1-9]+.[0-9]+.[0-9]+.*/

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+    http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>bintray-algolia-maven</id>
+            <username>${env.BINTRAY_USER}</username>
+            <password>${env.BINTRAY_API_KEY}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
This commit adds an extra step to the CircleCI configuration to release
the project to Bintray if and only if the CI is passing on a semver
tagged commit from master and all tests are passing.

In essence, it prevents the releaser to locally configure Maven and
fetch credentials and let CircleCI perform the `mvn deploy` on its own.

You can find extra configuration information from the official CircleCI
blog at this address:
https://circleci.com/blog/optimizing-maven-builds-on-circleci/