### PR TITLE
chore: fix CircleCI filtering to release only tagged commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,16 +83,25 @@ workflows:
   version: 2
   build:
     jobs:
-      - format
-      - test-java-8
-      - test-java-11
+      - format:
+          filters:
+            tags:
+              only: /.*/
+      - test-java-8:
+          filters:
+            tags:
+              only: /.*/
+      - test-java-11:
+          filters:
+            tags:
+              only: /.*/
       - release:
           requires:
             - format
             - test-java-8
             - test-java-11
           filters:
-            branches:
-              only: master
             tags:
               only: /^[1-9]+.[0-9]+.[0-9]+.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
See https://discuss.circleci.com/t/workflow-job-with-tag-filter-being-run-for-every-commit/20762/4
for more details (short answer: CircleCI filters are ORed instead of
ANDed since 2.0, also, all required jobs needs to accepts all tags).