### PR TITLE
feat(rules): client side information consequence in rules

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Consequence.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Consequence.java
@@ -60,9 +60,19 @@ public class Consequence implements Serializable {
     return this;
   }
 
+  public RenderingContent getRenderingContent() {
+    return renderingContent;
+  }
+
+  public Consequence setRenderingContent(RenderingContent renderingContent) {
+    this.renderingContent = renderingContent;
+    return this;
+  }
+
   private ConsequenceParams params;
   private List<ConsequencePromote> promote;
   private Map<String, Object> userData;
   private List<Hide> hide;
   private Boolean filterPromotes;
+  private RenderingContent renderingContent;
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/FacetMerchandising.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/FacetMerchandising.java
@@ -1,0 +1,25 @@
+package com.algolia.search.models.rules;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.io.Serializable;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FacetMerchandising implements Serializable {
+  private List<String> order;
+
+  public FacetMerchandising() {}
+
+  public FacetMerchandising(List<String> order) {
+    this.order = order;
+  }
+
+  public List<String> getOrder() {
+    return order;
+  }
+
+  public FacetMerchandising setOrder(List<String> order) {
+    this.order = order;
+    return this;
+  }
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Redirect.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/Redirect.java
@@ -1,0 +1,24 @@
+package com.algolia.search.models.rules;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.io.Serializable;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Redirect implements Serializable {
+  private String url;
+
+  public Redirect() {}
+
+  public Redirect(String url) {
+    this.url = url;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public Redirect setUrl(String url) {
+    this.url = url;
+    return this;
+  }
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/RenderingContent.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/RenderingContent.java
@@ -1,0 +1,48 @@
+package com.algolia.search.models.rules;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.io.Serializable;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RenderingContent implements Serializable {
+
+  private Redirect redirect;
+  private FacetMerchandising facetMerchandising;
+  private Map<String, Object> userData;
+
+  // For serialization
+  public RenderingContent() {}
+
+  public RenderingContent(Redirect redirect, FacetMerchandising facetMerchandising) {
+    this.redirect = redirect;
+    this.facetMerchandising = facetMerchandising;
+  }
+
+  public Redirect getRedirect() {
+    return redirect;
+  }
+
+  public RenderingContent setRedirect(Redirect redirect) {
+    this.redirect = redirect;
+    return this;
+  }
+
+  public FacetMerchandising getFacetMerchandising() {
+    return facetMerchandising;
+  }
+
+  public RenderingContent setFacetMerchandising(FacetMerchandising facetMerchandising) {
+    this.facetMerchandising = facetMerchandising;
+    return this;
+  }
+
+  public Map<String, Object> getUserData() {
+    return userData;
+  }
+
+  public RenderingContent setUserData(Map<String, Object> userData) {
+    this.userData = userData;
+    return this;
+  }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #729 
| Need Doc update   | yes


## Describe your change

Adds the new consequence `consequence.renderingContent`, which contains an object where each top level attribute is restricted to known use cases. The currently identified use cases are:
* Redirect
* Facet merchandising / ordering
* User defined data
