### PR TITLE
fix(osgi): add missing embedded classes to the exported packages

### DIFF
--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -17,6 +17,7 @@
     </dependencies>
     <properties>
         <relocated.org.apache>com.algolia.search.org.apache</relocated.org.apache>
+        <relocated.com.fasterxml.jackson>com.algolia.search.com.fasterxml.jackson</relocated.com.fasterxml.jackson>
     </properties>
     <build>
         <plugins>
@@ -48,7 +49,11 @@
                         <Bundle-SymbolicName>com.algolia.algoliasearch-apache-uber</Bundle-SymbolicName>
                         <Bundle-Name>algoliasearch-apache-uber</Bundle-Name>
                         <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>com.algolia.search.*,${relocated.org.apache}.http.impl.nio.client</Export-Package>
+                        <Export-Package>
+                            com.algolia.search.*,
+                            ${relocated.org.apache}.http.impl.nio.client,
+                            ${relocated.com.fasterxml.jackson}.annotation.JsonInclude.Include
+                        </Export-Package>
                         <Import-Package>
                             javax.net.ssl,javax.naming,!org.apache.avalon.framework.logger,!org.apache.log,!javax.servlet,*
                         </Import-Package>

--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>5.1.1</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -52,7 +52,8 @@
                         <Export-Package>
                             com.algolia.search.*,
                             ${relocated.org.apache}.http.impl.nio.client,
-                            ${relocated.com.fasterxml.jackson}.annotation.JsonInclude.Include
+                            ${relocated.com.fasterxml.jackson}.annotation,
+                            ${relocated.com.fasterxml.jackson}.databind
                         </Export-Package>
                         <Import-Package>
                             javax.net.ssl,javax.naming,!org.apache.avalon.framework.logger,!org.apache.log,!javax.servlet,*
@@ -91,11 +92,21 @@
                                         <exclude>META-INF/**</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <relocations combine.children="append">
                                 <relocation>
                                     <pattern>org.apache</pattern>
                                     <shadedPattern>${relocated.org.apache}</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>${relocated.com.fasterxml.jackson}</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -50,7 +50,7 @@
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>com.algolia.search.*,${relocated.org.apache}.http.impl.nio.client</Export-Package>
                         <Import-Package>
-                            javax.net.ssl,javax.naming,!org.apache.avalon.framework.logger,!org.apache.log,*
+                            javax.net.ssl,javax.naming,!org.apache.avalon.framework.logger,!org.apache.log,!javax.servlet,*
                         </Import-Package>
                         <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>

--- a/example-osgi/pom.xml
+++ b/example-osgi/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.algolia</groupId>
     <artifactId>example-osgi</artifactId>
-    <version>3.9.0</version>
+    <version>3.12.1</version>
     <packaging>bundle</packaging>
 
     <properties>
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.algolia</groupId>
             <artifactId>algoliasearch-apache-uber</artifactId>
-            <version>3.9.0</version>
+            <version>3.12.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/example-osgi/src/main/java/com/algolia/example/osgi/AlgoliaIndexingObject.java
+++ b/example-osgi/src/main/java/com/algolia/example/osgi/AlgoliaIndexingObject.java
@@ -1,0 +1,66 @@
+package com.algolia.example.osgi;
+
+
+import com.algolia.search.com.fasterxml.jackson.annotation.JsonInclude;
+import com.algolia.search.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AlgoliaIndexingObject extends AlgoliaWithId {
+
+    public String getProperty() {
+        return property;
+    }
+
+    public AlgoliaIndexingObject setProperty(String property) {
+        this.property = property;
+        return this;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public AlgoliaIndexingObject setTags(List<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    private String property = "default";
+
+    @JsonProperty("_tags")
+    private List<String> tags;
+
+    public AlgoliaIndexingObject() {
+    }
+
+    public AlgoliaIndexingObject(String objectID) {
+        setObjectID(objectID);
+    }
+
+    public AlgoliaIndexingObject(String objectID, String property) {
+        setObjectID(objectID);
+        this.property = property;
+    }
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@SuppressWarnings("WeakerAccess")
+class AlgoliaWithId implements Serializable {
+
+    public AlgoliaWithId() {
+    }
+
+    public String getObjectID() {
+        return id;
+    }
+
+    public void setObjectID(String objectID) {
+        this.id = objectID;
+    }
+
+    @JsonProperty("objectID")
+    private String id;
+}

--- a/example-osgi/src/main/java/com/algolia/example/osgi/DemoBundle.java
+++ b/example-osgi/src/main/java/com/algolia/example/osgi/DemoBundle.java
@@ -2,20 +2,40 @@ package com.algolia.example.osgi;
 
 import com.algolia.search.DefaultSearchClient;
 import com.algolia.search.SearchClient;
+import com.algolia.search.SearchIndex;
 import com.algolia.search.models.indexing.IndicesResponse;
+import com.algolia.search.models.indexing.Query;
+import com.algolia.search.models.indexing.SearchResult;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class DemoBundle implements BundleActivator {
+
+    public static String userName = System.getProperty("user.name");
+    private static String osName = System.getProperty("os.name").trim();
+    private static String javaVersion = System.getProperty("java.version");
+
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         String appID = System.getenv("ALGOLIA_APPLICATION_ID_1");
         String apiKey = System.getenv("ALGOLIA_ADMIN_KEY_1");
         SearchClient client = DefaultSearchClient.create(appID, apiKey);
         List<IndicesResponse> indices = client.listIndices();
-        System.out.printf("Algolia Demo Bundle is starting (listIndices() listed %d indices)\n", indices.size());
+        System.out.printf("Algolia Demo Bundle is starting (listIndices() listed %d indices)%n", indices.size());
+
+        IndicesResponse firstIndex = indices.get(0);
+        SearchIndex<AlgoliaIndexingObject> index = client.initIndex(firstIndex.getName(), AlgoliaIndexingObject.class);
+        SearchResult<AlgoliaIndexingObject> search = index.search(new Query());
+        System.out.printf("[%s] Hit founds: %s%n", firstIndex.getName(), search.getNbHits());
+    }
+
+    public static String getTestIndexName(String indexName) {
+        ZonedDateTime utc = ZonedDateTime.now(ZoneOffset.UTC);
+        return String.format("java_jvm_%s_%s_%s_%s_%s", javaVersion, utc, osName, userName, indexName);
     }
 
     @Override


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Fix OSGi bundle:
* Add `com.algolia.search.com.fasterxml.jackson.annotation.JsonInclude.Include` to package exports.
* Exclude `javax.servlet` from the package imports.