### PR TITLE
feat(indices): add missing fields to IndicesResponse

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/IndicesResponse.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/IndicesResponse.java
@@ -1,7 +1,9 @@
 package com.algolia.search.models.indexing;
 
+import com.algolia.search.models.analytics.ABTest;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 public class IndicesResponse implements Serializable {
   public String getName() {
@@ -85,6 +87,42 @@ public class IndicesResponse implements Serializable {
     return this;
   }
 
+  public List<String> getReplicas() {
+    return replicas;
+  }
+
+  public IndicesResponse setReplicas(List<String> replicas) {
+    this.replicas = replicas;
+    return this;
+  }
+
+  public String getPrimary() {
+    return primary;
+  }
+
+  public IndicesResponse setPrimary(String primary) {
+    this.primary = primary;
+    return this;
+  }
+
+  public String getSourceABTest() {
+    return sourceABTest;
+  }
+
+  public IndicesResponse setSourceABTest(String sourceABTest) {
+    this.sourceABTest = sourceABTest;
+    return this;
+  }
+
+  public ABTest getAbTest() {
+    return abTest;
+  }
+
+  public IndicesResponse setAbTest(ABTest abTest) {
+    this.abTest = abTest;
+    return this;
+  }
+
   private String name;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;
@@ -94,4 +132,8 @@ public class IndicesResponse implements Serializable {
   private long lastBuildTimes;
   private long numberOfPendingTasks;
   private boolean pendingTask;
+  private List<String> replicas;
+  private String primary;
+  private String sourceABTest;
+  private ABTest abTest;
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Adds missing fields to `IndicesResponse`:
- [x] `replicas`
- [x] `primary`
- [x] `sourceABTest`
- [x] `abTest`