### PR TITLE
fix(rules): custom serialization for `TimeRange`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,18 +87,15 @@ jobs:
 workflows:
   version: 2
   build:
-    codestyle:
-      jobs:
-        - format:
-            filters:
-              tags:
-                only: /.*/
-    test-java-8:
-      jobs:
-        - test-java-8:
-            filters:
-              tags:
-                only: /.*/
+    jobs:
+      - format:
+          filters:
+            tags:
+              only: /.*/
+      - test-java-8:
+          filters:
+            tags:
+              only: /.*/
       - test-java-11:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,15 +87,18 @@ jobs:
 workflows:
   version: 2
   build:
-    jobs:
-      - format:
-          filters:
-            tags:
-              only: /.*/
-      - test-java-8:
-          filters:
-            tags:
-              only: /.*/
+    codestyle:
+      jobs:
+        - format:
+            filters:
+              tags:
+                only: /.*/
+    test-java-8:
+      jobs:
+        - test-java-8:
+            filters:
+              tags:
+                only: /.*/
       - test-java-11:
           filters:
             tags:

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
@@ -66,15 +66,14 @@ class TimeRangeDeserializer extends JsonDeserializer<TimeRange> {
   @Override
   public TimeRange deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
     JsonNode node = p.getCodec().readTree(p);
-
+    // 'from' unix timestamp
     int fromTimestamp = (Integer) node.get("from").numberValue();
     Instant fromInstant = Instant.ofEpochSecond(fromTimestamp);
     OffsetDateTime from = OffsetDateTime.ofInstant(fromInstant, ZoneOffset.UTC);
-
+    // 'until' unix timestamp
     int untilTimestamp = (Integer) node.get("until").numberValue();
     Instant untilInstant = Instant.ofEpochSecond(untilTimestamp);
     OffsetDateTime until = OffsetDateTime.ofInstant(untilInstant, ZoneOffset.UTC);
-
     return new TimeRange(from, until);
   }
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
@@ -1,17 +1,28 @@
 package com.algolia.search.models.rules;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.IOException;
 import java.io.Serializable;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonSerialize(using = TimeRangeSerializer.class)
+@JsonDeserialize(using = TimeRangeDeserializer.class)
 public class TimeRange implements Serializable {
 
-  @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT)
   private OffsetDateTime from;
 
-  @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT)
   private OffsetDateTime until;
 
   public TimeRange() {}
@@ -35,5 +46,35 @@ public class TimeRange implements Serializable {
 
   public void setUntil(OffsetDateTime until) {
     this.until = until;
+  }
+}
+
+class TimeRangeSerializer extends JsonSerializer<TimeRange> {
+
+  @Override
+  public void serialize(TimeRange value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeStartObject();
+    gen.writeObjectField("from", value.getFrom().toEpochSecond());
+    gen.writeObjectField("until", value.getUntil().toEpochSecond());
+    gen.writeEndObject();
+  }
+}
+
+class TimeRangeDeserializer extends JsonDeserializer<TimeRange> {
+
+  @Override
+  public TimeRange deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    JsonNode node = p.getCodec().readTree(p);
+
+    int fromTimestamp = (Integer) node.get("from").numberValue();
+    Instant fromInstant = Instant.ofEpochSecond(fromTimestamp);
+    OffsetDateTime from = OffsetDateTime.ofInstant(fromInstant, ZoneOffset.UTC);
+
+    int untilTimestamp = (Integer) node.get("until").numberValue();
+    Instant untilInstant = Instant.ofEpochSecond(untilTimestamp);
+    OffsetDateTime until = OffsetDateTime.ofInstant(untilInstant, ZoneOffset.UTC);
+
+    return new TimeRange(from, until);
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -991,7 +991,7 @@ class JacksonParserTest {
     assertThat(json).isEqualTo("{\"from\":1619807400,\"until\":1630263239}");
 
     TimeRange retrieveTimeRange = Defaults.getObjectMapper().readValue(json, TimeRange.class);
-    assertThat(timerange.getFrom().isEqual(retrieveTimeRange.getFrom())).isTrue();
-    assertThat(timerange.getUntil().isEqual(retrieveTimeRange.getUntil())).isTrue();
+    assertThat(timerange.getFrom()).isEqualTo(retrieveTimeRange.getFrom());
+    assertThat(timerange.getUntil()).isEqualTo(retrieveTimeRange.getUntil());
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -20,6 +20,7 @@ import com.algolia.search.models.rules.ConsequenceQuery;
 import com.algolia.search.models.rules.Edit;
 import com.algolia.search.models.rules.EditType;
 import com.algolia.search.models.rules.Rule;
+import com.algolia.search.models.rules.TimeRange;
 import com.algolia.search.models.settings.Distinct;
 import com.algolia.search.models.settings.IgnorePlurals;
 import com.algolia.search.models.settings.IndexSettings;
@@ -28,6 +29,8 @@ import com.algolia.search.models.settings.TypoTolerance;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -973,5 +976,22 @@ class JacksonParserTest {
     // Multiple ObjectIDs case
     assertThat(promote.get(1).getObjectID()).isNull();
     assertThat(promote.get(1).getObjectIDs()).isEqualTo(Arrays.asList("b", "c"));
+  }
+
+  @Test
+  void rulesValidityTimeRange() throws IOException {
+    ZoneOffset offset = ZoneOffset.of("+05:30");
+    // Nanoseconds precisions will be lost and should not be considered.
+    TimeRange timerange =
+        new TimeRange(
+            OffsetDateTime.of(2021, 5, 1, 0, 0, 0, 0, offset),
+            OffsetDateTime.of(2021, 8, 30, 0, 23, 59, 0, offset));
+
+    String json = Defaults.getObjectMapper().writeValueAsString(timerange);
+    assertThat(json).isEqualTo("{\"from\":1619807400,\"until\":1630263239}");
+
+    TimeRange retrieveTimeRange = Defaults.getObjectMapper().readValue(json, TimeRange.class);
+    assertThat(timerange.getFrom().isEqual(retrieveTimeRange.getFrom())).isTrue();
+    assertThat(timerange.getUntil().isEqual(retrieveTimeRange.getUntil())).isTrue();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.4.0</junit.version>
-        <assertj-core.version>3.12.1</assertj-core.version>
+        <assertj-core.version>3.19.0</assertj-core.version>
         <jsr305.version>3.0.2</jsr305.version>
         <doclint>none</doclint>
     </properties>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Specify custom serialization for `TimeRange`, using Unix timestamps in seconds.

## What problem is this fixing?

Rule's validity time ranges (from, until) only support integer Unix timestamps in seconds. 
The client's Jackson configuration serializes/deserializes those values using millisecond timestamps.
From Jackson's `JavaTimeModule`:

> For serialization, timestamps are written as fractional numbers (decimals), where the number is seconds and the decimal is fractional seconds, (...) If WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS is disabled, timestamps are written as a whole number of milliseconds.
