### PR TITLE
fix(query): accessing empty nested `List<List<?>>`

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/util/QueryStringUtils.java
@@ -69,7 +69,7 @@ public class QueryStringUtils {
                         List<Object> tmpList = (List) e.getValue();
 
                         // Work around for nested List<List<?>> could be improved
-                        if (tmpList.get(0) != null && tmpList.get(0) instanceof List<?>) {
+                        if (!tmpList.isEmpty() && tmpList.get(0) instanceof List<?>) {
 
                           List<List<Object>> listOfList = (List) e.getValue();
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #748 
| Need Doc update   | no


## Describe your change

* Add list emptiness check
* Remove unnecessary `null` check; `instanceof` returns `false` for nulls
