### PR TITLE
feat: expose transport allowing custom requests

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/AnalyticsClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/AnalyticsClient.java
@@ -6,7 +6,12 @@ import com.algolia.search.exceptions.AlgoliaRuntimeException;
 import com.algolia.search.exceptions.LaunderThrowable;
 import com.algolia.search.models.HttpMethod;
 import com.algolia.search.models.RequestOptions;
-import com.algolia.search.models.analytics.*;
+import com.algolia.search.models.analytics.ABTest;
+import com.algolia.search.models.analytics.ABTestResponse;
+import com.algolia.search.models.analytics.ABTests;
+import com.algolia.search.models.analytics.AddABTestResponse;
+import com.algolia.search.models.analytics.DeleteAbTestResponse;
+import com.algolia.search.models.analytics.StopAbTestResponse;
 import com.algolia.search.models.common.CallType;
 import java.io.Closeable;
 import java.io.IOException;
@@ -65,6 +70,11 @@ public final class AnalyticsClient implements Closeable {
   /** Get Client's configuration */
   public ConfigBase getConfig() {
     return config;
+  }
+
+  /** Transport object responsible for the serialization/deserialization and the retry strategy. */
+  public HttpTransport getTransport() {
+    return transport;
   }
 
   /** Get an A/B test information and results. */

--- a/algoliasearch-core/src/main/java/com/algolia/search/InsightsClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/InsightsClient.java
@@ -71,6 +71,11 @@ public final class InsightsClient implements Closeable {
     return config;
   }
 
+  /** Transport object responsible for the serialization/deserialization and the retry strategy. */
+  public HttpTransport getTransport() {
+    return transport;
+  }
+
   /** @param userToken the user config */
   public UserInsightsClient user(@Nonnull String userToken) {
     return new UserInsightsClient(userToken, this);

--- a/algoliasearch-core/src/main/java/com/algolia/search/PersonalizationClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/PersonalizationClient.java
@@ -67,6 +67,11 @@ public class PersonalizationClient implements Closeable {
     transport.close();
   }
 
+  /** Transport object responsible for the serialization/deserialization and the retry strategy. */
+  public HttpTransport getTransport() {
+    return transport;
+  }
+
   /**
    * Returns the personalization strategy of the application
    *

--- a/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
@@ -50,6 +50,7 @@ public final class RecommendClient implements Closeable {
     transport.close();
   }
 
+  /** Transport object responsible for the serialization/deserialization and the retry strategy. */
   public HttpTransport getTransport() {
     return transport;
   }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | yes


## Describe your change

`SearchClient` allows custom requests through `customRequest` and/or exposing `transport` object.

This PR adds `getTransport()` to the other clients, allowing direct access to `executeRequestAsync` to run custom requests.