### PR TITLE
fix(recommendation): `_score` field as member of `RecommendHit`

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
@@ -7,13 +7,12 @@ import com.algolia.search.models.common.CallType;
 import com.algolia.search.models.indexing.RecommendHit;
 import com.algolia.search.models.indexing.RecommendationsResult;
 import com.algolia.search.models.recommend.*;
-
-import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
 
 /**
  * Algolia's REST recommend client that wraps an instance of the transporter {@link HttpTransport}

--- a/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
@@ -4,18 +4,16 @@ import com.algolia.search.exceptions.LaunderThrowable;
 import com.algolia.search.models.HttpMethod;
 import com.algolia.search.models.RequestOptions;
 import com.algolia.search.models.common.CallType;
+import com.algolia.search.models.indexing.RecommendHit;
 import com.algolia.search.models.indexing.RecommendationsResult;
-import com.algolia.search.models.recommend.FrequentlyBoughtTogetherQuery;
-import com.algolia.search.models.recommend.GetRecommendationsResponse;
-import com.algolia.search.models.recommend.RecommendationsQuery;
-import com.algolia.search.models.recommend.RecommendationsRequests;
-import com.algolia.search.models.recommend.RelatedProductsQuery;
+import com.algolia.search.models.recommend.*;
+
+import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nonnull;
 
 /**
  * Algolia's REST recommend client that wraps an instance of the transporter {@link HttpTransport}
@@ -64,19 +62,9 @@ public final class RecommendClient implements Closeable {
    * Returns recommendations for a specific model and objectID.
    *
    * @param requests a list of recommendation requests to execute
-   */
-  public List<RecommendationsResult<Object>> getRecommendations(
-      @Nonnull List<RecommendationsQuery> requests) {
-    return LaunderThrowable.await(getRecommendationsAsync(requests));
-  }
-
-  /**
-   * Returns recommendations for a specific model and objectID.
-   *
-   * @param requests a list of recommendation requests to execute
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    */
-  public <T> List<RecommendationsResult<T>> getRecommendations(
+  public <T extends RecommendHit> List<RecommendationsResult<T>> getRecommendations(
       @Nonnull List<RecommendationsQuery> requests, @Nonnull Class<T> clazz) {
     return LaunderThrowable.await(getRecommendationsAsync(requests, clazz));
   }
@@ -88,7 +76,7 @@ public final class RecommendClient implements Closeable {
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    * @param requestOptions options to pass to this request
    */
-  public <T> List<RecommendationsResult<T>> getRecommendations(
+  public <T extends RecommendHit> List<RecommendationsResult<T>> getRecommendations(
       @Nonnull List<RecommendationsQuery> requests,
       @Nonnull Class<T> clazz,
       RequestOptions requestOptions) {
@@ -99,20 +87,11 @@ public final class RecommendClient implements Closeable {
    * Returns recommendations for a specific model and objectID.
    *
    * @param requests a list of recommendation requests to execute
-   */
-  public CompletableFuture<List<RecommendationsResult<Object>>> getRecommendationsAsync(
-      @Nonnull List<RecommendationsQuery> requests) {
-    return getRecommendationsAsync(requests, Object.class, null);
-  }
-
-  /**
-   * Returns recommendations for a specific model and objectID.
-   *
-   * @param requests a list of recommendation requests to execute
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    */
-  public <T> CompletableFuture<List<RecommendationsResult<T>>> getRecommendationsAsync(
-      @Nonnull List<RecommendationsQuery> requests, @Nonnull Class<T> clazz) {
+  public <T extends RecommendHit>
+      CompletableFuture<List<RecommendationsResult<T>>> getRecommendationsAsync(
+          @Nonnull List<RecommendationsQuery> requests, @Nonnull Class<T> clazz) {
     return getRecommendationsAsync(requests, clazz, null);
   }
 
@@ -123,10 +102,11 @@ public final class RecommendClient implements Closeable {
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    * @param requestOptions options to pass to this request
    */
-  public <T> CompletableFuture<List<RecommendationsResult<T>>> getRecommendationsAsync(
-      @Nonnull List<RecommendationsQuery> requests,
-      @Nonnull Class<T> clazz,
-      RequestOptions requestOptions) {
+  public <T extends RecommendHit>
+      CompletableFuture<List<RecommendationsResult<T>>> getRecommendationsAsync(
+          @Nonnull List<RecommendationsQuery> requests,
+          @Nonnull Class<T> clazz,
+          RequestOptions requestOptions) {
     Objects.requireNonNull(requests);
     Objects.requireNonNull(clazz);
     RecommendationsRequests<RecommendationsQuery> data = new RecommendationsRequests<>(requests);
@@ -139,19 +119,9 @@ public final class RecommendClient implements Closeable {
    * Returns related products recommendations for a specific model and objectID.
    *
    * @param requests a list of recommendation requests to execute
-   */
-  public List<RecommendationsResult<Object>> getRelatedProducts(
-      @Nonnull List<RelatedProductsQuery> requests) {
-    return LaunderThrowable.await(getRelatedProductsAsync(requests));
-  }
-
-  /**
-   * Returns related products recommendations for a specific model and objectID.
-   *
-   * @param requests a list of recommendation requests to execute
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    */
-  public <T> List<RecommendationsResult<T>> getRelatedProducts(
+  public <T extends RecommendHit> List<RecommendationsResult<T>> getRelatedProducts(
       @Nonnull List<RelatedProductsQuery> requests, @Nonnull Class<T> clazz) {
     return LaunderThrowable.await(getRelatedProductsAsync(requests, clazz));
   }
@@ -163,7 +133,7 @@ public final class RecommendClient implements Closeable {
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    * @param requestOptions options to pass to this request
    */
-  public <T> List<RecommendationsResult<T>> getRelatedProducts(
+  public <T extends RecommendHit> List<RecommendationsResult<T>> getRelatedProducts(
       @Nonnull List<RelatedProductsQuery> requests,
       @Nonnull Class<T> clazz,
       RequestOptions requestOptions) {
@@ -174,20 +144,11 @@ public final class RecommendClient implements Closeable {
    * Returns related products recommendations for a specific model and objectID.
    *
    * @param requests a list of recommendation requests to execute
-   */
-  public CompletableFuture<List<RecommendationsResult<Object>>> getRelatedProductsAsync(
-      @Nonnull List<RelatedProductsQuery> requests) {
-    return getRelatedProductsAsync(requests, Object.class);
-  }
-
-  /**
-   * Returns related products recommendations for a specific model and objectID.
-   *
-   * @param requests a list of recommendation requests to execute
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    */
-  public <T> CompletableFuture<List<RecommendationsResult<T>>> getRelatedProductsAsync(
-      @Nonnull List<RelatedProductsQuery> requests, @Nonnull Class<T> clazz) {
+  public <T extends RecommendHit>
+      CompletableFuture<List<RecommendationsResult<T>>> getRelatedProductsAsync(
+          @Nonnull List<RelatedProductsQuery> requests, @Nonnull Class<T> clazz) {
     return getRelatedProductsAsync(requests, clazz, null);
   }
 
@@ -198,10 +159,11 @@ public final class RecommendClient implements Closeable {
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    * @param requestOptions options to pass to this request
    */
-  public <T> CompletableFuture<List<RecommendationsResult<T>>> getRelatedProductsAsync(
-      @Nonnull List<RelatedProductsQuery> requests,
-      @Nonnull Class<T> clazz,
-      RequestOptions requestOptions) {
+  public <T extends RecommendHit>
+      CompletableFuture<List<RecommendationsResult<T>>> getRelatedProductsAsync(
+          @Nonnull List<RelatedProductsQuery> requests,
+          @Nonnull Class<T> clazz,
+          RequestOptions requestOptions) {
     Objects.requireNonNull(requests);
     Objects.requireNonNull(clazz);
     RecommendationsRequests<RelatedProductsQuery> data = new RecommendationsRequests<>(requests);
@@ -214,19 +176,9 @@ public final class RecommendClient implements Closeable {
    * Returns frequently bought together recommendations for a specific model and objectID.
    *
    * @param requests a list of recommendation requests to execute
-   */
-  public List<RecommendationsResult<Object>> getFrequentlyBoughtTogether(
-      @Nonnull List<FrequentlyBoughtTogetherQuery> requests) {
-    return LaunderThrowable.await(getFrequentlyBoughtTogetherAsync(requests));
-  }
-
-  /**
-   * Returns frequently bought together recommendations for a specific model and objectID.
-   *
-   * @param requests a list of recommendation requests to execute
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    */
-  public <T> List<RecommendationsResult<T>> getFrequentlyBoughtTogether(
+  public <T extends RecommendHit> List<RecommendationsResult<T>> getFrequentlyBoughtTogether(
       @Nonnull List<FrequentlyBoughtTogetherQuery> requests, @Nonnull Class<T> clazz) {
     return LaunderThrowable.await(getFrequentlyBoughtTogetherAsync(requests, clazz));
   }
@@ -238,7 +190,7 @@ public final class RecommendClient implements Closeable {
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    * @param requestOptions options to pass to this request
    */
-  public <T> List<RecommendationsResult<T>> getFrequentlyBoughtTogether(
+  public <T extends RecommendHit> List<RecommendationsResult<T>> getFrequentlyBoughtTogether(
       @Nonnull List<FrequentlyBoughtTogetherQuery> requests,
       @Nonnull Class<T> clazz,
       RequestOptions requestOptions) {
@@ -250,20 +202,11 @@ public final class RecommendClient implements Closeable {
    * Returns frequently bought together recommendations for a specific model and objectID.
    *
    * @param requests a list of recommendation requests to execute
-   */
-  public CompletableFuture<List<RecommendationsResult<Object>>> getFrequentlyBoughtTogetherAsync(
-      @Nonnull List<FrequentlyBoughtTogetherQuery> requests) {
-    return getFrequentlyBoughtTogetherAsync(requests, Object.class, null);
-  }
-
-  /**
-   * Returns frequently bought together recommendations for a specific model and objectID.
-   *
-   * @param requests a list of recommendation requests to execute
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    */
-  public <T> CompletableFuture<List<RecommendationsResult<T>>> getFrequentlyBoughtTogetherAsync(
-      @Nonnull List<FrequentlyBoughtTogetherQuery> requests, @Nonnull Class<T> clazz) {
+  public <T extends RecommendHit>
+      CompletableFuture<List<RecommendationsResult<T>>> getFrequentlyBoughtTogetherAsync(
+          @Nonnull List<FrequentlyBoughtTogetherQuery> requests, @Nonnull Class<T> clazz) {
     return getFrequentlyBoughtTogetherAsync(requests, clazz, null);
   }
 
@@ -274,10 +217,11 @@ public final class RecommendClient implements Closeable {
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    * @param requestOptions options to pass to this request
    */
-  public <T> CompletableFuture<List<RecommendationsResult<T>>> getFrequentlyBoughtTogetherAsync(
-      @Nonnull List<FrequentlyBoughtTogetherQuery> requests,
-      @Nonnull Class<T> clazz,
-      RequestOptions requestOptions) {
+  public <T extends RecommendHit>
+      CompletableFuture<List<RecommendationsResult<T>>> getFrequentlyBoughtTogetherAsync(
+          @Nonnull List<FrequentlyBoughtTogetherQuery> requests,
+          @Nonnull Class<T> clazz,
+          RequestOptions requestOptions) {
     Objects.requireNonNull(requests);
     Objects.requireNonNull(clazz);
     RecommendationsRequests<FrequentlyBoughtTogetherQuery> data =
@@ -287,8 +231,9 @@ public final class RecommendClient implements Closeable {
   // endregion
 
   @SuppressWarnings("unchecked")
-  private <T> CompletableFuture<List<RecommendationsResult<T>>> performGetRecommends(
-      Class<T> clazz, RequestOptions requestOptions, RecommendationsRequests<?> data) {
+  private <T extends RecommendHit>
+      CompletableFuture<List<RecommendationsResult<T>>> performGetRecommends(
+          Class<T> clazz, RequestOptions requestOptions, RecommendationsRequests<?> data) {
     return transport
         .executeRequestAsync(
             HttpMethod.POST,

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RecommendHit.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RecommendHit.java
@@ -1,7 +1,6 @@
 package com.algolia.search.models.indexing;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import javax.annotation.Nonnull;
 
 /** Recommend hit, similar to a search hit but associated with a score. */

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RecommendHit.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RecommendHit.java
@@ -1,0 +1,14 @@
+package com.algolia.search.models.indexing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nonnull;
+
+/** Recommend hit, similar to a search hit but associated with a score. */
+public interface RecommendHit {
+
+  /** Confidence score of the recommended item, the closer it’s to 100, the more relevant. */
+  @Nonnull
+  @JsonProperty("_score")
+  Float getScore();
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RecommendationsResult.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/RecommendationsResult.java
@@ -1,15 +1,4 @@
 package com.algolia.search.models.indexing;
 
-public class RecommendationsResult<T> extends SearchResult<T> {
-
-  private Integer score;
-
-  public Integer getScore() {
-    return score;
-  }
-
-  public RecommendationsResult<T> setScore(Integer score) {
-    this.score = score;
-    return this;
-  }
-}
+/** Result of a recommendation request. */
+public class RecommendationsResult<T extends RecommendHit> extends SearchResult<T> {}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/recommend/GetRecommendationsResponse.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/recommend/GetRecommendationsResponse.java
@@ -1,15 +1,19 @@
 package com.algolia.search.models.recommend;
 
+import com.algolia.search.models.indexing.RecommendHit;
 import com.algolia.search.models.indexing.RecommendationsResult;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.io.Serializable;
 import java.util.List;
 
+/** Response from Recommend API. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GetRecommendationsResponse<T> implements Serializable {
+public class GetRecommendationsResponse<T extends RecommendHit> implements Serializable {
 
+  /** List of results in the order they were submitted, one per request. */
   private List<RecommendationsResult<T>> results;
 
   public List<RecommendationsResult<T>> getResults() {

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/recommend/GetRecommendationsResponse.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/recommend/GetRecommendationsResponse.java
@@ -4,7 +4,6 @@ import com.algolia.search.models.indexing.RecommendHit;
 import com.algolia.search.models.indexing.RecommendationsResult;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.io.Serializable;
 import java.util.List;
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -1,5 +1,9 @@
 package com.algolia.search;
 
+import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
+import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.algolia.search.integration.models.RecommendObject;
 import com.algolia.search.models.common.InnerQuery;
 import com.algolia.search.models.indexing.*;
@@ -9,18 +13,13 @@ import com.algolia.search.models.settings.*;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-
-import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
-import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JacksonParserTest {
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/models/RecommendObject.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/models/RecommendObject.java
@@ -2,7 +2,6 @@ package com.algolia.search.integration.models;
 
 import com.algolia.search.models.indexing.RecommendHit;
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import javax.annotation.Nonnull;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/models/RecommendObject.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/models/RecommendObject.java
@@ -1,0 +1,35 @@
+package com.algolia.search.integration.models;
+
+import com.algolia.search.models.indexing.RecommendHit;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import javax.annotation.Nonnull;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RecommendObject implements RecommendHit {
+
+  private String objectID;
+  private Float score;
+
+  public RecommendObject() {}
+
+  public RecommendObject(String objectID, Float score) {
+    this.objectID = objectID;
+    this.score = score;
+  }
+
+  public String getObjectID() {
+    return objectID;
+  }
+
+  public RecommendObject setObjectID(String objectID) {
+    this.objectID = objectID;
+    return this;
+  }
+
+  @Nonnull
+  @Override
+  public Float getScore() {
+    return score;
+  }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | yes


## Describe your change

This fixes `_score` field, which is a property of `hits` not `results` as mentioned in the [doc](https://www.algolia.com/doc/rest-api/recommend/#get-recommendations).

_PS: this PR removes recommendation calls with `hits` as list of `Object`s since this can never be the case._