### PR TITLE
feat(recommend): add default recommend hit class

### DIFF
--- a/algoliasearch-apache/src/test/java/com/algolia/search/recommend/RecommendTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/recommend/RecommendTest.java
@@ -1,0 +1,30 @@
+package com.algolia.search.recommend;
+
+import com.algolia.search.DefaultRecommendClient;
+import com.algolia.search.IntegrationTestExtension;
+import com.algolia.search.RecommendClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+
+@Disabled
+@ExtendWith({IntegrationTestExtension.class})
+class RecommendTest extends com.algolia.search.integration.recommend.RecommendTest {
+
+  private static final RecommendClient recommendClient =
+      DefaultRecommendClient.create(ALGOLIA_APPLICATION_ID_1, ALGOLIA_ADMIN_KEY_1);
+
+  RecommendTest() {
+    super(recommendClient);
+  }
+
+  @AfterAll
+  static void close() throws IOException {
+    recommendClient.close();
+  }
+}

--- a/algoliasearch-apache/src/test/java/com/algolia/search/recommend/RecommendTest.java
+++ b/algoliasearch-apache/src/test/java/com/algolia/search/recommend/RecommendTest.java
@@ -1,16 +1,15 @@
 package com.algolia.search.recommend;
 
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
+import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
+
 import com.algolia.search.DefaultRecommendClient;
 import com.algolia.search.IntegrationTestExtension;
 import com.algolia.search.RecommendClient;
+import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.io.IOException;
-
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_ADMIN_KEY_1;
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
 
 @Disabled
 @ExtendWith({IntegrationTestExtension.class})

--- a/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
@@ -4,15 +4,17 @@ import com.algolia.search.exceptions.LaunderThrowable;
 import com.algolia.search.models.HttpMethod;
 import com.algolia.search.models.RequestOptions;
 import com.algolia.search.models.common.CallType;
+import com.algolia.search.models.indexing.DefaultRecommendHit;
 import com.algolia.search.models.indexing.RecommendHit;
 import com.algolia.search.models.indexing.RecommendationsResult;
 import com.algolia.search.models.recommend.*;
+
+import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nonnull;
 
 /**
  * Algolia's REST recommend client that wraps an instance of the transporter {@link HttpTransport}
@@ -57,6 +59,11 @@ public final class RecommendClient implements Closeable {
   }
 
   // region get_recommendations
+
+  public List<RecommendationsResult<DefaultRecommendHit>> getRecommendations(
+      @Nonnull List<RecommendationsQuery> requests) {
+    return LaunderThrowable.await(getRecommendationsAsync(requests, DefaultRecommendHit.class));
+  }
   /**
    * Returns recommendations for a specific model and objectID.
    *
@@ -118,6 +125,16 @@ public final class RecommendClient implements Closeable {
    * Returns related products recommendations for a specific model and objectID.
    *
    * @param requests a list of recommendation requests to execute
+   */
+  public List<RecommendationsResult<DefaultRecommendHit>> getRelatedProducts(
+      @Nonnull List<RelatedProductsQuery> requests) {
+    return LaunderThrowable.await(getRelatedProductsAsync(requests, DefaultRecommendHit.class));
+  }
+
+  /**
+   * Returns related products recommendations for a specific model and objectID.
+   *
+   * @param requests a list of recommendation requests to execute
    * @param clazz The class held by the index. Could be your business object or {@link Object}
    */
   public <T extends RecommendHit> List<RecommendationsResult<T>> getRelatedProducts(
@@ -171,6 +188,17 @@ public final class RecommendClient implements Closeable {
   // endregion
 
   // region get_frequently_bought_together
+  /**
+   * Returns frequently bought together recommendations for a specific model and objectID.
+   *
+   * @param requests a list of recommendation requests to execute
+   */
+  public List<RecommendationsResult<DefaultRecommendHit>> getFrequentlyBoughtTogether(
+      @Nonnull List<FrequentlyBoughtTogetherQuery> requests) {
+    return LaunderThrowable.await(
+        getFrequentlyBoughtTogetherAsync(requests, DefaultRecommendHit.class));
+  }
+
   /**
    * Returns frequently bought together recommendations for a specific model and objectID.
    *

--- a/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/RecommendClient.java
@@ -8,13 +8,12 @@ import com.algolia.search.models.indexing.DefaultRecommendHit;
 import com.algolia.search.models.indexing.RecommendHit;
 import com.algolia.search.models.indexing.RecommendationsResult;
 import com.algolia.search.models.recommend.*;
-
-import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
 
 /**
  * Algolia's REST recommend client that wraps an instance of the transporter {@link HttpTransport}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/DefaultRecommendHit.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/DefaultRecommendHit.java
@@ -1,0 +1,41 @@
+package com.algolia.search.models.indexing;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Default Recommend hit implementation */
+public class DefaultRecommendHit implements RecommendHit {
+
+  private Map<String, Object> fields = new HashMap<>();
+  private Float score;
+
+  @Nonnull
+  @Override
+  public Float getScore() {
+    return score;
+  }
+
+  public DefaultRecommendHit setScore(Float score) {
+    this.score = score;
+    fields.put("_score", score);
+    return this;
+  }
+
+  public Map<String, Object> getFields() {
+    return fields;
+  }
+
+  public DefaultRecommendHit setFields(Map<String, Object> fields) {
+    this.fields = fields;
+    return this;
+  }
+
+  @JsonAnySetter
+  public DefaultRecommendHit setField(String key, Object value) {
+    this.fields.put(key, value);
+    return this;
+  }
+}

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/DefaultRecommendHit.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/DefaultRecommendHit.java
@@ -1,10 +1,9 @@
 package com.algolia.search.models.indexing;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /** Default Recommend hit implementation */
 public class DefaultRecommendHit implements RecommendHit {

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -1,5 +1,9 @@
 package com.algolia.search;
 
+import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
+import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.algolia.search.integration.models.RecommendObject;
 import com.algolia.search.models.common.InnerQuery;
 import com.algolia.search.models.indexing.*;
@@ -9,18 +13,13 @@ import com.algolia.search.models.settings.*;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-
-import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
-import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JacksonParserTest {
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -1,9 +1,5 @@
 package com.algolia.search;
 
-import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
-import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.algolia.search.integration.models.RecommendObject;
 import com.algolia.search.models.common.InnerQuery;
 import com.algolia.search.models.indexing.*;
@@ -13,13 +9,18 @@ import com.algolia.search.models.settings.*;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
+import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class JacksonParserTest {
 
@@ -1002,6 +1003,22 @@ class JacksonParserTest {
     RecommendationsResult<RecommendObject> result = recommendations.getResults().get(0);
     RecommendObject recommendHit = result.getHits().get(0);
     assertThat(recommendHit.getObjectID()).isEqualTo("D05927-8161-111");
+    assertThat(recommendHit.getScore()).isEqualTo(32.72f);
+  }
+
+  @Test
+  void recommendationsDefault() throws JsonProcessingException {
+    String json =
+        "{\"results\":[{\"hits\":[{\"_highlightResult\":{\"category\":{\"matchLevel\":\"none\",\"matchedWords\":[],\"value\":\"Men - T-Shirts\"},\"image_link\":{\"matchLevel\":\"none\",\"matchedWords\":[],\"value\":\"https:\\/\\/example.org\\/image\\/D05927-8161-111-F01.jpg\"},\"name\":{\"matchLevel\":\"none\",\"matchedWords\":[],\"value\":\"Jirgi Half-Zip T-Shirt\"}},\"_score\":32.72,\"category\":\"Men - T-Shirts\",\"image_link\":\"https:\\/\\/example.org\\/image\\/D05927-8161-111-F01.jpg\",\"name\":\"Jirgi Half-Zip T-Shirt\",\"objectID\":\"D05927-8161-111\",\"position\":105,\"url\":\"men\\/t-shirts\\/d05927-8161-111\"}],\"hitsPerPage\":1,\"nbHits\":1,\"nbPages\":1,\"page\":0,\"processingTimeMS\":6,\"renderingContent\":{}}]}";
+    JavaType type =
+        Defaults.getObjectMapper()
+            .getTypeFactory()
+            .constructParametricType(GetRecommendationsResponse.class, DefaultRecommendHit.class);
+    GetRecommendationsResponse<DefaultRecommendHit> recommendations =
+        Defaults.getObjectMapper().readValue(json, type);
+    RecommendationsResult<DefaultRecommendHit> result = recommendations.getResults().get(0);
+    DefaultRecommendHit recommendHit = result.getHits().get(0);
+    assertThat(recommendHit.getFields().get("objectID")).isEqualTo("D05927-8161-111");
     assertThat(recommendHit.getScore()).isEqualTo(32.72f);
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/recommend/RecommendTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/recommend/RecommendTest.java
@@ -1,5 +1,7 @@
 package com.algolia.search.integration.recommend;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.algolia.search.RecommendClient;
 import com.algolia.search.integration.models.RecommendObject;
 import com.algolia.search.models.indexing.DefaultRecommendHit;
@@ -7,13 +9,10 @@ import com.algolia.search.models.indexing.RecommendationsResult;
 import com.algolia.search.models.recommend.FrequentlyBoughtTogetherQuery;
 import com.algolia.search.models.recommend.RecommendationsQuery;
 import com.algolia.search.models.recommend.RelatedProductsQuery;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public abstract class RecommendTest {
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/recommend/RecommendTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/recommend/RecommendTest.java
@@ -1,0 +1,73 @@
+package com.algolia.search.integration.recommend;
+
+import com.algolia.search.RecommendClient;
+import com.algolia.search.integration.models.RecommendObject;
+import com.algolia.search.models.indexing.DefaultRecommendHit;
+import com.algolia.search.models.indexing.RecommendationsResult;
+import com.algolia.search.models.recommend.FrequentlyBoughtTogetherQuery;
+import com.algolia.search.models.recommend.RecommendationsQuery;
+import com.algolia.search.models.recommend.RelatedProductsQuery;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class RecommendTest {
+
+  private final RecommendClient recommendClient;
+
+  public RecommendTest(RecommendClient recommendClient) {
+    this.recommendClient = recommendClient;
+  }
+
+  @Test
+  void testGetRecommends() {
+    RecommendationsQuery queryRelatedProducts =
+        new RecommendationsQuery("MyIndexName", "related-products", "MyObjectID");
+    RecommendationsQuery queryBoughtTogether =
+        new RecommendationsQuery("MyIndexName", "bought-together", "MyObjectID");
+
+    List<RecommendationsResult<DefaultRecommendHit>> recommendationsDefault =
+        recommendClient.getRecommendations(
+            Arrays.asList(queryRelatedProducts, queryBoughtTogether));
+    assertThat(recommendationsDefault.size()).isEqualTo(2);
+
+    List<RecommendationsResult<RecommendObject>> recommendations =
+        recommendClient.getRecommendations(
+            Arrays.asList(queryRelatedProducts, queryBoughtTogether), RecommendObject.class);
+    assertThat(recommendations.size()).isEqualTo(2);
+  }
+
+  @Test
+  void testRelatedProducts() {
+    RelatedProductsQuery queryRelatedProducts =
+        new RelatedProductsQuery("MyIndexName", "MyObjectID");
+
+    List<RecommendationsResult<DefaultRecommendHit>> recommendationsDefault =
+        recommendClient.getRelatedProducts(Collections.singletonList(queryRelatedProducts));
+    assertThat(recommendationsDefault.size()).isEqualTo(2);
+
+    List<RecommendationsResult<RecommendObject>> recommendations =
+        recommendClient.getRelatedProducts(
+            Collections.singletonList(queryRelatedProducts), RecommendObject.class);
+    assertThat(recommendations.size()).isEqualTo(2);
+  }
+
+  @Test
+  void testFrequentlyBoughtTogether() {
+    FrequentlyBoughtTogetherQuery queryBoughtTogether =
+        new FrequentlyBoughtTogetherQuery("MyIndexName", "MyObjectID");
+
+    List<RecommendationsResult<DefaultRecommendHit>> recommendationsDefault =
+        recommendClient.getFrequentlyBoughtTogether(Collections.singletonList(queryBoughtTogether));
+    assertThat(recommendationsDefault.size()).isEqualTo(2);
+
+    List<RecommendationsResult<RecommendObject>> recommendations =
+        recommendClient.getFrequentlyBoughtTogether(
+            Collections.singletonList(queryBoughtTogether), RecommendObject.class);
+    assertThat(recommendations.size()).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   |  no


## Describe your change

Most clients have search methods without hit type, not ideal, but they are there for convenience.
This PR adds a default implementation for `RecommendHit`, and a default recommend search method without hit type to match the other clients.