### PR TITLE
fix: serialize `ConsequenceParams` empty query

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceQuery.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceQuery.java
@@ -1,7 +1,6 @@
 package com.algolia.search.models.rules;
 
 import com.algolia.search.Defaults;
-import com.algolia.search.util.AlgoliaUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceQuery.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/ConsequenceQuery.java
@@ -80,7 +80,7 @@ class ConsequenceQuerySerializer extends JsonSerializer<ConsequenceQuery> {
      * Consequence query edits will override regular "query" - both can't be set at the same time
      * https://www.algolia.com/doc/api-reference/api-methods/save-rule/#method-param-query
      * */
-    if (!AlgoliaUtils.isNullOrEmptyWhiteSpace(value.getQueryString())) {
+    if (value.getQueryString() != null) {
       gen.writeString(value.getQueryString());
     } else {
       gen.writeStartObject();

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -1,5 +1,9 @@
 package com.algolia.search;
 
+import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
+import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.algolia.search.integration.models.RecommendObject;
 import com.algolia.search.models.common.InnerQuery;
 import com.algolia.search.models.indexing.*;
@@ -9,18 +13,13 @@ import com.algolia.search.models.settings.*;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-
-import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
-import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JacksonParserTest {
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -1,9 +1,5 @@
 package com.algolia.search;
 
-import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
-import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.algolia.search.integration.models.RecommendObject;
 import com.algolia.search.models.common.InnerQuery;
 import com.algolia.search.models.indexing.*;
@@ -13,13 +9,18 @@ import com.algolia.search.models.settings.*;
 import com.algolia.search.models.synonyms.SynonymQuery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.algolia.search.models.synonyms.SynonymType.ALT_CORRECTION_1;
+import static com.algolia.search.models.synonyms.SynonymType.ONE_WAY_SYNONYM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class JacksonParserTest {
 
@@ -1003,5 +1004,12 @@ class JacksonParserTest {
     RecommendObject recommendHit = result.getHits().get(0);
     assertThat(recommendHit.getObjectID()).isEqualTo("D05927-8161-111");
     assertThat(recommendHit.getScore()).isEqualTo(32.72f);
+  }
+
+  @Test
+  void consequenceParams_emptyQuery_nullEdits() throws JsonProcessingException {
+    ConsequenceParams params = new ConsequenceParams().setQuery("");
+    String json = Defaults.getObjectMapper().writeValueAsString(params);
+    assertThat(json).isEqualTo("{\"query\":\"\"}");
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Serialize `ConsequenceParams`'s  query when empty.
