### PR TITLE
fix: copySettings func not calling expected base func

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/SearchClientCopyOperations.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/SearchClientCopyOperations.java
@@ -28,7 +28,7 @@ public interface SearchClientCopyOperations extends SearchClientBase {
    * @throws AlgoliaRuntimeException When an error occurred during the serialization
    */
   default CopyResponse copySettings(@Nonnull String sourceIndex, @Nonnull String destinationIndex) {
-    return LaunderThrowable.await(copyIndexAsync(sourceIndex, destinationIndex));
+    return LaunderThrowable.await(copySettingsAsync(sourceIndex, destinationIndex));
   }
 
   /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     



## Describe your change

The `copySettings` method was calling base method `copyIndex` instead of `copySettings`, leading to unexpected behavior: all scopes being copied instead of only the settings.

