### PR TITLE
feat: TimeRange: deserialize time as long

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
@@ -67,11 +67,11 @@ class TimeRangeDeserializer extends JsonDeserializer<TimeRange> {
   public TimeRange deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
     JsonNode node = p.getCodec().readTree(p);
     // 'from' unix timestamp
-    int fromTimestamp = (Integer) node.get("from").numberValue();
+    long fromTimestamp = node.get("from").asLong();
     Instant fromInstant = Instant.ofEpochSecond(fromTimestamp);
     OffsetDateTime from = OffsetDateTime.ofInstant(fromInstant, ZoneOffset.UTC);
     // 'until' unix timestamp
-    int untilTimestamp = (Integer) node.get("until").numberValue();
+    long untilTimestamp = node.get("until").asLong();
     Instant untilInstant = Instant.ofEpochSecond(untilTimestamp);
     OffsetDateTime until = OffsetDateTime.ofInstant(untilInstant, ZoneOffset.UTC);
     return new TimeRange(from, until);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

Homogenize JSON deserialization of TimeRange with serialization, using `long` for timestamps.

## What problem is this fixing?

Some customers build rules with an end date very far away in the future, which cannot be captured as number of seconds from epoch with an int.