### PR TITLE
build: fail on warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.5.1</version>
+                        <version>3.9.0</version>
                         <configuration>
                             <source>1.8</source>
                             <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
                             <source>1.8</source>
                             <target>1.8</target>
                             <release>8</release>
+                            <showWarnings>true</showWarnings>
+                            <failOnWarning>true</failOnWarning>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
                         <configuration>
                             <source>1.8</source>
                             <target>1.8</target>
+                            <release>8</release>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
                         <configuration>
                             <source>1.8</source>
                             <target>1.8</target>
-                            <release>8</release>
                             <showWarnings>true</showWarnings>
                             <failOnWarning>true</failOnWarning>
                         </configuration>
@@ -200,6 +199,15 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-9-and-above</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
         </profile>
         <profile>
             <id>release</id>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

This change makes maven (show and) fail on warning, to avoid inserting subtile problems only showed as warnings.

Typically, while introducing this behavior, it became obvious that the `javac` was actually complaining that the bootstrap classpath was not set appropriately for the target level of Java on my machine (and possibly on the CI's), which could lead to inconsistencies in production. Setting `<release>` to 8 is necessary to point `javac` to the correct JDK (i.e. 8) and to avoid it using whatever JDK it used as default at bootstrap while compiling for a different level.

The `<release>` maven directive adds a `--release` to the arguments to `javac`; this flag is only available starting from JDK9. Maven doesn't selectively set this flag depending on the level of compiler used; a profile is necessary for that, activated by the level of JDK used for compiling.

(Note that there may be several profiles active, so this is not breaking the current setup; this can be assessed by running `mvn help:active-profiles`)

## What problem is this fixing?

Showing warnings does not fix anything by itself, it allows for stricter coding style.

Telling `javac` to use the JDK8 when releasing ensures that the created package is compatible with Java 8's runtime (`<source>8` ensures that the source code only uses constructions supported by Java 8, `<target>8` forces the compiler to generate only bytecode compatible with Java 8; `<release>8` tells the compiler to check for JDK's APIs).
See also:
- [Maven compiler plugin doc on `<release>`](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html)
- [Stackoverflow discussion](https://stackoverflow.com/questions/59049980/maven-compiler-release-as-an-replacement-for-source-and-target)