### PR TITLE
fix: optional filters deserialization

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
@@ -29,12 +29,8 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
 
     switch (currentToken) {
       case START_ARRAY:
-        List list = p.readValueAs(List.class);
-        if (list.stream().allMatch(String.class::isInstance)) { // are all elements strings?
-          result = Collections.singletonList(list);
-        } else {
-          result = buildFilters(list);
-        }
+        List<Object> list = p.readValueAs(List.class);
+        result = buildFilters(list);
         break;
       case VALUE_STRING:
         result = Collections.singletonList(Arrays.asList(p.getValueAsString().split(",")));
@@ -64,3 +60,4 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
             .collect(Collectors.toList());
   }
 }
+

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
@@ -33,10 +33,8 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
         result = buildFilters(list);
         break;
       case VALUE_STRING:
-        result =
-            Arrays.stream(p.getValueAsString().split(","))
-                .map(Collections::singletonList)
-                .collect(Collectors.toList());
+        String string = p.getValueAsString();
+        result = buildFilters(string);
         break;
       case VALUE_NULL:
         break;
@@ -48,6 +46,7 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
     return result;
   }
 
+  /** Build filters from a list */
   @SuppressWarnings("unchecked")
   private List<List<String>> buildFilters(List list) {
     return (List<List<String>>)
@@ -61,5 +60,17 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
                   }
                 })
             .collect(Collectors.toList());
+  }
+
+  /** Build filters from (legacy) string */
+  private List<List<String>> buildFilters(String string) {
+    if (string.startsWith("(") && string.endsWith(")")) {
+      String input = string.substring(1, string.length() - 1);
+      return Collections.singletonList(Arrays.asList(input.split(",")));
+    } else {
+      return Arrays.stream(string.split(","))
+          .map(Collections::singletonList)
+          .collect(Collectors.toList());
+    }
   }
 }

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
@@ -60,4 +60,3 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
             .collect(Collectors.toList());
   }
 }
-

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,7 +34,10 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
         result = buildFilters(list);
         break;
       case VALUE_STRING:
-        result = Collections.singletonList(Arrays.asList(p.getValueAsString().split(",")));
+        result =
+            Arrays.stream(p.getValueAsString().split(","))
+                .map(Collections::singletonList)
+                .collect(Collectors.toList());
         break;
       case VALUE_NULL:
         break;

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/FiltersJsonDeserializer.java
@@ -64,13 +64,18 @@ class FiltersJsonDeserializer extends JsonDeserializer<List<List<String>>> {
 
   /** Build filters from (legacy) string */
   private List<List<String>> buildFilters(String string) {
-    if (string.startsWith("(") && string.endsWith(")")) {
-      String input = string.substring(1, string.length() - 1);
-      return Collections.singletonList(Arrays.asList(input.split(",")));
-    } else {
-      return Arrays.stream(string.split(","))
-          .map(Collections::singletonList)
-          .collect(Collectors.toList());
-    }
+    // Extract groups: "(A:1,B:2),C:3" -> ["(A:1,B:2)","C:3"]
+    List<String> groups = Arrays.asList(string.split(",(?![^()]*\\))"));
+    return groups.stream()
+        .map(
+            group -> {
+              if (group.startsWith("(") && group.endsWith(")")) {
+                String input = group.substring(1, group.length() - 1);
+                return Arrays.asList(input.split(","));
+              } else {
+                return Collections.singletonList(group);
+              }
+            })
+        .collect(Collectors.toList());
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -174,7 +174,6 @@ class JacksonParserTest {
     // Testing "one string" legacy filters => should be converted to "ANDED" filters
     // [["color:green"],["color:yellow"]]
     String stringFilters = String.format("{\"%s\":\"color:green,color:yellow\"}", input);
-
     assertANDEDListResult(
         extractFilters(
             Defaults.getObjectMapper().readValue(stringFilters, ConsequenceParams.class), input));
@@ -191,6 +190,15 @@ class JacksonParserTest {
     assertOREDResult(
         extractFilters(
             Defaults.getObjectMapper().readValue(nestedArrayFilters, ConsequenceParams.class),
+            input));
+
+    // Testing "one string with parenthesis" legacy filters => should be converted to "ORED" filters
+    // [["color:green", "color:yellow"]]
+    String stringParenthesisFilters =
+        String.format("{\"%s\":\"(color:green,color:yellow)\"}", input);
+    assertOREDResult(
+        extractFilters(
+            Defaults.getObjectMapper().readValue(stringParenthesisFilters, ConsequenceParams.class),
             input));
 
     // Testing mixed case with array and string

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -193,16 +193,16 @@ class JacksonParserTest {
             input));
 
     // Testing "one string with parenthesis" legacy filters => should be converted to "ORED" filters
-    // [["color:green", "color:yellow"]]
+    // [["color:green", "color:yellow"], ["color:blue"]]
     String stringParenthesisFilters =
-        String.format("{\"%s\":\"(color:green,color:yellow)\"}", input);
-    assertOREDResult(
+        String.format("{\"%s\":\"(color:green,color:yellow),color:blue\"}", input);
+    assertOREDLatestResult(
         extractFilters(
             Defaults.getObjectMapper().readValue(stringParenthesisFilters, ConsequenceParams.class),
             input));
 
     // Testing mixed case with array and string
-    // [["color:green","color:yellow"],"color:blue"]
+    // [["color:green","color:yellow"], ["color:blue"]]
     String stringAndArrayFilters =
         String.format("{\"%s\":[[\"color:green\",\"color:yellow\"],\"color:blue\"]}", input);
     List<List<String>> mixedDeserialized =

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -171,18 +171,18 @@ class JacksonParserTest {
   @ValueSource(strings = {"facetFilters", "optionalFilters", "tagFilters", "numericFilters"})
   void testLegacyFiltersFormat(String input) throws IOException {
 
-    // Testing "one string" legacy filters => should be converted to "ORED" nested filters
-    // [["color:green","color:yellow"]]
+    // Testing "one string" legacy filters => should be converted to "ANDED" filters
+    // [["color:green"],["color:yellow"]]
     String stringFilters = String.format("{\"%s\":\"color:green,color:yellow\"}", input);
 
-    assertOREDResult(
+    assertANDEDListResult(
         extractFilters(
             Defaults.getObjectMapper().readValue(stringFilters, ConsequenceParams.class), input));
 
-    // Testing "one array" legacy filters => should be converted to "ORED" nested filters
+    // Testing "one array" legacy filters => should be converted to "ANDED" filters
     // [["color:green"],["color:yellow"]]
     String arrayFilters = String.format("{\"%s\":[\"color:green\",\"color:yellow\"]}", input);
-    assertOREDListResult(
+    assertANDEDListResult(
         extractFilters(
             Defaults.getObjectMapper().readValue(arrayFilters, ConsequenceParams.class), input));
 

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -182,7 +182,7 @@ class JacksonParserTest {
     // Testing "one array" legacy filters => should be converted to "ORED" nested filters
     // [["color:green","color:yellow"]]
     String arrayFilters = String.format("{\"%s\":[\"color:green\",\"color:yellow\"]}", input);
-    assertOREDResult(
+    assertOREDListResult(
         extractFilters(
             Defaults.getObjectMapper().readValue(arrayFilters, ConsequenceParams.class), input));
 
@@ -240,6 +240,14 @@ class JacksonParserTest {
     assertThat(result.get(0)).hasSize(2);
     assertThat(result.get(0)).containsSequence("color:green");
     assertThat(result.get(0)).containsSequence("color:yellow");
+  }
+
+  void assertOREDListResult(List<List<String>> result) {
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).hasSize(1);
+    assertThat(result.get(0)).containsSequence("color:green");
+    assertThat(result.get(1)).hasSize(1);
+    assertThat(result.get(1)).containsSequence("color:yellow");
   }
 
   void assertOREDLatestResult(List<List<String>> result) {

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -180,7 +180,7 @@ class JacksonParserTest {
             Defaults.getObjectMapper().readValue(stringFilters, ConsequenceParams.class), input));
 
     // Testing "one array" legacy filters => should be converted to "ORED" nested filters
-    // [["color:green","color:yellow"]]
+    // [["color:green"],["color:yellow"]]
     String arrayFilters = String.format("{\"%s\":[\"color:green\",\"color:yellow\"]}", input);
     assertOREDListResult(
         extractFilters(
@@ -242,7 +242,7 @@ class JacksonParserTest {
     assertThat(result.get(0)).containsSequence("color:yellow");
   }
 
-  void assertOREDListResult(List<List<String>> result) {
+  void assertANDEDListResult(List<List<String>> result) {
     assertThat(result).hasSize(2);
     assertThat(result.get(0)).hasSize(1);
     assertThat(result.get(0)).containsSequence("color:green");


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Fixes `optionalFilters` deserialization for following special cases: 
* `["A:1", "B:2"]` ->   `[["A:1"], ["B:2"]]`
* `"A:1", "B:2"`  ->   `[["A:1"], ["B:2"]]`