### PR TITLE
feat: add default utility classes for `java-net`

### DIFF
--- a/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultAnalyticsClient.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultAnalyticsClient.java
@@ -1,0 +1,59 @@
+package com.algolia.search;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Algolia's REST analytics client that wraps an instance of the transporter. which wraps the HTTP
+ * Client This client allows to build typed requests and read typed responses. Requests are made
+ * under the Algolia's retry-strategy. This client is intended to be reused and it's thread-safe.
+ *
+ * @see <a href="https://www.algolia.com/doc/rest-api/analytics/">Algolia.com</a>
+ */
+public class DefaultAnalyticsClient {
+
+  // Suppress default constructor for noninstantiability
+  private DefaultAnalyticsClient() {
+    throw new AssertionError();
+  }
+
+  /**
+   * Creates a default {@link AnalyticsClient} with the given credentials. The default HttpClient
+   * implementation is {@link ApacheHttpRequester}
+   *
+   * @param applicationID The Algolia Application ID
+   * @param apiKey The Algolia API Key
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static AnalyticsClient create(@Nonnull String applicationID, @Nonnull String apiKey) {
+    return create(applicationID, apiKey, "us");
+  }
+
+  /**
+   * Creates a default {@link AnalyticsClient} with the given credentials. The default HttpClient
+   * implementation is {@link ApacheHttpRequester}
+   *
+   * @param applicationID The Algolia Application ID
+   * @param apiKey The Algolia API Key
+   * @param region The region of the Analytics cluster
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static AnalyticsClient create(
+      @Nonnull String applicationID, @Nonnull String apiKey, @Nonnull String region) {
+    return create(new AnalyticsConfig.Builder(applicationID, apiKey, region).build());
+  }
+
+  /**
+   * Creates a default {@link AnalyticsClient} with the given {@link AnalyticsConfig}. The default
+   * HttpClient implementation is {@link ApacheHttpRequester}
+   *
+   * @param config The configuration allows you to advanced configuration of the clients such as
+   *     batch size or custom hosts and timeout.
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey/Config is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static AnalyticsClient create(@Nonnull AnalyticsConfig config) {
+    return new AnalyticsClient(config, new JavaNetHttpRequester(config));
+  }
+}

--- a/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultInsightsClient.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultInsightsClient.java
@@ -1,0 +1,44 @@
+package com.algolia.search;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Algolia's REST insights client that wraps an instance of the transporter. which wraps the HTTP
+ * Client This client allows to build typed requests and read typed responses. Requests are made
+ * under the Algolia's retry-strategy. This client is intended to be reused and it's thread-safe.
+ *
+ * @see <a href="https://www.algolia.com/doc/rest-api/insights/">Algolia.com</a>
+ */
+public class DefaultInsightsClient {
+
+  // Suppress default constructor for noninstantiability
+  private DefaultInsightsClient() {
+    throw new AssertionError();
+  }
+
+  /**
+   * Creates a default {@link InsightsClient} with the given credentials. The default HttpClient
+   * implementation is {@link ApacheHttpRequester}
+   *
+   * @param applicationID The Algolia Application ID
+   * @param apiKey The Algolia API Key
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static InsightsClient create(@Nonnull String applicationID, @Nonnull String apiKey) {
+    return create(new InsightsConfig.Builder(applicationID, apiKey).build());
+  }
+
+  /**
+   * Creates a default {@link InsightsClient} with the given {@link InsightsConfig}. The default
+   * HttpClient implementation is {@link ApacheHttpRequester}
+   *
+   * @param config The configuration allows you to advanced configuration of the clients such as
+   *     batch size or custom hosts and timeout.
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey/Config is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static InsightsClient create(@Nonnull InsightsConfig config) {
+    return new InsightsClient(config, new JavaNetHttpRequester(config));
+  }
+}

--- a/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultPersonalizationClient.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultPersonalizationClient.java
@@ -1,0 +1,47 @@
+package com.algolia.search;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Algolia's REST recommendation client that wraps an instance of the transporter {@link
+ * HttpTransport} which wraps the HTTP Client This client allows to build typed requests and read
+ * typed responses. Requests are made under the Algolia's retry-strategy. This client is intended to
+ * be reused and it's thread-safe.
+ *
+ * @see <a href="https://www.algolia.com/doc/rest-api/personalization/">Algolia.com</a>
+ */
+public class DefaultPersonalizationClient {
+
+  // Suppress default constructor for noninstantiability
+  private DefaultPersonalizationClient() {
+    throw new AssertionError();
+  }
+
+  /**
+   * Creates a {@link PersonalizationClient} with the given credentials The default HttpClient
+   * implementation is {@link ApacheHttpRequester}
+   *
+   * @param applicationID The Algolia Application ID
+   * @param apiKey The Algolia API Key
+   * @param region Region where your personalization data is stored and processed.
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static PersonalizationClient create(
+      @Nonnull String applicationID, @Nonnull String apiKey, @Nonnull String region) {
+    return create(new PersonalizationConfig.Builder(applicationID, apiKey, region).build());
+  }
+
+  /**
+   * Creates a default {@link PersonalizationClient} with the given {@link SearchConfig}. The
+   * default HttpClient implementation is {@link ApacheHttpRequester}
+   *
+   * @param config The configuration allows you to advanced configuration of the clients such as
+   *     batch size or custom hosts and timeout.
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey/Config is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static PersonalizationClient create(@Nonnull PersonalizationConfig config) {
+    return new PersonalizationClient(config, new JavaNetHttpRequester(config));
+  }
+}

--- a/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultRecommendClient.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultRecommendClient.java
@@ -1,0 +1,45 @@
+package com.algolia.search;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Algolia's REST recommend client that wraps an instance of the transporter {@link HttpTransport}
+ * which wraps the HTTP Client This client allows to build typed requests and read typed responses.
+ * Requests are made under the Algolia's retry-strategy. This client is intended to be reused, and
+ * it's thread-safe.
+ *
+ * @see <a href="https://www.algolia.com/doc/rest-api/recommend">Algolia.com</a>
+ */
+public class DefaultRecommendClient {
+
+  // Suppress default constructor for noninstantiability
+  private DefaultRecommendClient() {
+    throw new AssertionError();
+  }
+
+  /**
+   * Creates a {@link RecommendClient} with the given credentials The default HttpClient
+   * implementation is {@link ApacheHttpRequester}
+   *
+   * @param applicationID The Algolia Application ID
+   * @param apiKey The Algolia API Key
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static RecommendClient create(@Nonnull String applicationID, @Nonnull String apiKey) {
+    return create(new SearchConfig.Builder(applicationID, apiKey).build());
+  }
+
+  /**
+   * Creates a default {@link RecommendClient} with the given {@link SearchConfig}. The default
+   * HttpClient implementation is {@link ApacheHttpRequester}
+   *
+   * @param config The configuration allows you to advanced configuration of the clients such as
+   *     batch size or custom hosts and timeout.
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey/Config is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static RecommendClient create(@Nonnull SearchConfig config) {
+    return new RecommendClient(config, new JavaNetHttpRequester(config));
+  }
+}

--- a/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultSearchClient.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/DefaultSearchClient.java
@@ -1,0 +1,44 @@
+package com.algolia.search;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Algolia's REST search client that wraps an instance of the transporter which wraps the HttpClient
+ * This client allows to build typed requests and read typed responses. Requests are made under the
+ * Algolia's retry-strategy. This client is intended to be reused and it's thread-safe.
+ *
+ * @see <a href="https://www.algolia.com/doc/rest-api/search/">Algolia.com</a>
+ */
+public class DefaultSearchClient {
+
+  // Suppress default constructor for noninstantiability
+  private DefaultSearchClient() {
+    throw new AssertionError();
+  }
+
+  /**
+   * Creates a {@link DefaultSearchClient} with the given credentials The default HttpClient
+   * implementation is {@link JavaNetHttpRequester}
+   *
+   * @param applicationID The Algolia Application ID
+   * @param apiKey The Algolia API Key
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static SearchClient create(@Nonnull String applicationID, @Nonnull String apiKey) {
+    return create(new SearchConfig.Builder(applicationID, apiKey).build());
+  }
+
+  /**
+   * Creates a default {@link DefaultSearchClient} with the given {@link SearchConfig}. The default
+   * HttpClient implementation is {@link ApacheHttpRequester}
+   *
+   * @param config The configuration allows you to advanced configuration of the clients such as
+   *     batch size or custom hosts and timeout.
+   * @throws NullPointerException If one of the following ApplicationID/ApiKey/Config is null
+   * @throws IllegalArgumentException If the ApplicationID or the APIKey are empty
+   */
+  public static SearchClient create(@Nonnull SearchConfig config) {
+    return new SearchClient(config, new JavaNetHttpRequester(config));
+  }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | Fixes #763
| Need Doc update   | no


## Describe your change

Have the same utility classes in both `apache` and `java-net` modules for clients instantiation:
* `DefaultSearchClient`
* `DefaultRecommendClient`
* `DefaultPersonalizationClient`
* `DefaultInsightsClient`
* `DefaultAnalyticsClient`

_Pitfall: using both `apache` and `java-net` at the same time may cause classes duplication errors._
