### PR TITLE
fix(HttpRequester): use body supplier

### DIFF
--- a/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
+++ b/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
@@ -5,6 +5,7 @@ import com.algolia.search.models.HttpRequest;
 import com.algolia.search.models.HttpResponse;
 import com.algolia.search.util.HttpStatusCodeUtils;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.util.Map;
@@ -133,19 +134,19 @@ public final class ApacheHttpRequester implements HttpRequester {
 
       case HttpPost.METHOD_NAME:
         HttpPost post = new HttpPost(algoliaRequest.getUri().toString());
-        if (algoliaRequest.getBody() != null) post.setEntity(addEntity(algoliaRequest));
+        if (algoliaRequest.getBodySupplier() != null) post.setEntity(addEntity(algoliaRequest));
         post.setConfig(buildRequestConfig(algoliaRequest));
         return addHeaders(post, algoliaRequest.getHeaders());
 
       case HttpPut.METHOD_NAME:
         HttpPut put = new HttpPut(algoliaRequest.getUri().toString());
-        if (algoliaRequest.getBody() != null) put.setEntity(addEntity(algoliaRequest));
+        if (algoliaRequest.getBodySupplier() != null) put.setEntity(addEntity(algoliaRequest));
         put.setConfig(buildRequestConfig(algoliaRequest));
         return addHeaders(put, algoliaRequest.getHeaders());
 
       case HttpPatch.METHOD_NAME:
         HttpPatch patch = new HttpPatch(algoliaRequest.getUri().toString());
-        if (algoliaRequest.getBody() != null) patch.setEntity(addEntity(algoliaRequest));
+        if (algoliaRequest.getBodySupplier() != null) patch.setEntity(addEntity(algoliaRequest));
         patch.setConfig(buildRequestConfig(algoliaRequest));
         return addHeaders(patch, algoliaRequest.getHeaders());
 
@@ -167,9 +168,9 @@ public final class ApacheHttpRequester implements HttpRequester {
 
   private HttpEntity addEntity(@Nonnull HttpRequest request) {
     try {
+      InputStream body = request.getBodySupplier().get();
       InputStreamEntity entity =
-          new InputStreamEntity(
-              request.getBody(), request.getBody().available(), ContentType.APPLICATION_JSON);
+          new InputStreamEntity(body, body.available(), ContentType.APPLICATION_JSON);
 
       if (request.canCompress()) {
         entity.setContentEncoding(Defaults.CONTENT_ENCODING_GZIP);

--- a/algoliasearch-core/src/main/java/com/algolia/search/HttpTransport.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/HttpTransport.java
@@ -3,13 +3,18 @@ package com.algolia.search;
 import com.algolia.search.exceptions.AlgoliaApiException;
 import com.algolia.search.exceptions.AlgoliaRetryException;
 import com.algolia.search.exceptions.AlgoliaRuntimeException;
-import com.algolia.search.models.*;
+import com.algolia.search.models.HttpMethod;
+import com.algolia.search.models.HttpRequest;
+import com.algolia.search.models.RequestOptions;
 import com.algolia.search.models.common.CallType;
 import com.algolia.search.util.CompletableFutureUtils;
 import com.algolia.search.util.QueryStringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
@@ -25,10 +30,10 @@ import javax.annotation.Nonnull;
  */
 public class HttpTransport {
 
+  private static final Logger LOGGER = Logger.getLogger(HttpTransport.class.getName());
   private final HttpRequester httpRequester;
   private final RetryStrategy retryStrategy;
   private final ConfigBase config;
-  private static final Logger LOGGER = Logger.getLogger(HttpTransport.class.getName());
 
   HttpTransport(@Nonnull ConfigBase config, @Nonnull HttpRequester httpRequester) {
     this.config = config;
@@ -221,7 +226,7 @@ public class HttpTransport {
         new HttpRequest(method, fullPath, headersToSend, timeout, config.getCompressionType());
 
     if (data != null) {
-      request.setBody(serializeJSON(data, request));
+      request.setBodySupplier(() -> serializeJSON(data, request));
       logRequest(request, data);
     }
 

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/HttpRequest.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/HttpRequest.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class HttpRequest {
 
@@ -62,10 +63,14 @@ public class HttpRequest {
     return this;
   }
 
+  /** @deprecated produced input stream is not reusable, use {@link #getBodySupplier()} instead. */
+  @Deprecated
   public InputStream getBody() {
     return body;
   }
 
+  /** @deprecated use {@link #setBodySupplier(Supplier)} instead. */
+  @Deprecated
   public HttpRequest setBody(InputStream body) {
     this.body = body;
     return this;
@@ -109,11 +114,21 @@ public class HttpRequest {
     this.timeout *= (retryCount + 1);
   }
 
+  public Supplier<InputStream> getBodySupplier() {
+    return bodySupplier;
+  }
+
+  public HttpRequest setBodySupplier(Supplier<InputStream> bodySupplier) {
+    this.bodySupplier = bodySupplier;
+    return this;
+  }
+
   private HttpMethod method;
   private URL uri;
   private String methodPath;
   private Map<String, String> headers;
-  private InputStream body;
+  private InputStream body; // deprecated since, not reusable
   private int timeout;
   private CompressionType compressionType;
+  private Supplier<InputStream> bodySupplier;
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/RetryStrategyE2ETest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/RetryStrategyE2ETest.java
@@ -1,32 +1,31 @@
 package com.algolia.search;
 
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_APPLICATION_ID_1;
-import static com.algolia.search.integration.TestHelpers.ALGOLIA_SEARCH_KEY_1;
-import static com.algolia.search.integration.TestHelpers.getTestIndexName;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.common.CallType;
 import com.algolia.search.models.indexing.Query;
 import com.algolia.search.models.indexing.SearchResult;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+
+import static com.algolia.search.integration.TestHelpers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class RetryStrategyE2ETest {
 
   protected final SearchClient searchClient;
+  protected final SearchConfig config;
   protected HttpRequester httpRequester;
   protected List<StatefulHost> customHosts;
-
-  protected final SearchConfig config;
 
   protected RetryStrategyE2ETest(SearchClient searchClient) {
     this.searchClient = searchClient;
     this.customHosts =
         Arrays.asList(
             new StatefulHost("expired.badssl.com", EnumSet.of(CallType.READ)),
+            new StatefulHost("http.badssl.com", EnumSet.of(CallType.READ)),
             new StatefulHost(
                 String.format("%s-dsn.algolia.net", ALGOLIA_APPLICATION_ID_1),
                 EnumSet.of(CallType.READ)));

--- a/algoliasearch-core/src/test/java/com/algolia/search/RetryStrategyE2ETest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/RetryStrategyE2ETest.java
@@ -1,17 +1,16 @@
 package com.algolia.search;
 
+import static com.algolia.search.integration.TestHelpers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.algolia.search.integration.models.AlgoliaObject;
 import com.algolia.search.models.common.CallType;
 import com.algolia.search.models.indexing.Query;
 import com.algolia.search.models.indexing.SearchResult;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-
-import static com.algolia.search.integration.TestHelpers.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public abstract class RetryStrategyE2ETest {
 

--- a/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.Nonnull;
 
@@ -112,7 +113,9 @@ public final class JavaNetHttpRequester implements HttpRequester {
   private BodyPublisher buildRequestBody(
       @Nonnull Builder builder, @Nonnull HttpRequest algoliaRequest) {
 
-    if (algoliaRequest.getBody() == null) {
+    Supplier<InputStream> bodySupplier = algoliaRequest.getBodySupplier();
+
+    if (bodySupplier == null) {
       return java.net.http.HttpRequest.BodyPublishers.noBody();
     }
 
@@ -122,7 +125,7 @@ public final class JavaNetHttpRequester implements HttpRequester {
       builder.header(Defaults.CONTENT_TYPE_HEADER, Defaults.APPLICATION_JSON);
     }
 
-    return BodyPublishers.ofInputStream(algoliaRequest::getBody);
+    return BodyPublishers.ofInputStream(bodySupplier);
   }
 
   /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #773   <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Instead of using the same `InputStream`, we use a `Supplier<InputStream>`, which produces a new `InputStream` at every retry attempt.
