### PR TITLE
fix: add cipher suites for TLSv1.3 and HTTP/2

### DIFF
--- a/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
@@ -4,9 +4,6 @@ import com.algolia.search.exceptions.AlgoliaRuntimeException;
 import com.algolia.search.models.HttpRequest;
 import com.algolia.search.models.HttpResponse;
 import com.algolia.search.util.HttpStatusCodeUtils;
-
-import javax.annotation.Nonnull;
-import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ProxySelector;
@@ -25,6 +22,8 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.zip.GZIPInputStream;
+import javax.annotation.Nonnull;
+import javax.net.ssl.SSLParameters;
 
 /** Implementation of {@code HttpRequester} for the built-in Java.net 11 HTTP Client */
 public final class JavaNetHttpRequester implements HttpRequester {

--- a/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
+++ b/algoliasearch-java-net/src/main/java/com/algolia/search/JavaNetHttpRequester.java
@@ -4,6 +4,9 @@ import com.algolia.search.exceptions.AlgoliaRuntimeException;
 import com.algolia.search.models.HttpRequest;
 import com.algolia.search.models.HttpResponse;
 import com.algolia.search.util.HttpStatusCodeUtils;
+
+import javax.annotation.Nonnull;
+import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ProxySelector;
@@ -22,10 +25,14 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.zip.GZIPInputStream;
-import javax.annotation.Nonnull;
 
 /** Implementation of {@code HttpRequester} for the built-in Java.net 11 HTTP Client */
 public final class JavaNetHttpRequester implements HttpRequester {
+
+  /** Cipher suites for TLSv1.3. */
+  private static final String[] TLSV13_CIPHER_SUITES = {
+    "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"
+  };
 
   /** Reusable instance of the httpClient. */
   private final HttpClient client;
@@ -40,10 +47,15 @@ public final class JavaNetHttpRequester implements HttpRequester {
         HttpClient.newBuilder()
             .executor(config.getExecutor())
             .version(HttpClient.Version.HTTP_2)
+            .sslParameters(sslParametersCiphers())
             .followRedirects(HttpClient.Redirect.NEVER)
             .proxy(ProxySelector.getDefault())
             .connectTimeout(Duration.ofMillis(config.getConnectTimeOut()))
             .build();
+  }
+
+  private SSLParameters sslParametersCiphers() {
+    return new SSLParameters(TLSV13_CIPHER_SUITES);
   }
 
   /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

In Java 11 (at least until `11.0.14`), when the API is configured with TLSv1.3 and HTTP/2, connections using them can not be established, this happens because no available cipher suite for TLSv1.3 can be found by default.

_PS: this issue does not appear in newer Java versions (i.g. Java 17) or by downgrading to HTTP/1.1_