### PR TITLE
fix(core): http request timeout overflow

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/HttpRequest.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/HttpRequest.java
@@ -111,7 +111,12 @@ public class HttpRequest {
   }
 
   public void incrementTimeout(int retryCount) {
-    this.timeout *= (retryCount + 1);
+    // check for overflow
+    if (timeout > 0 && retryCount > Integer.MAX_VALUE / timeout - 1) {
+      timeout = Integer.MAX_VALUE;
+    } else {
+      timeout *= (retryCount + 1);
+    }
   }
 
   public Supplier<InputStream> getBodySupplier() {

--- a/algoliasearch-core/src/test/java/com/algolia/search/HttpRequestTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/HttpRequestTest.java
@@ -1,0 +1,29 @@
+package com.algolia.search;
+
+import com.algolia.search.models.HttpMethod;
+import com.algolia.search.models.HttpRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpRequestTest {
+
+    @Test
+    void testIncrementTimeout() {
+        HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, "/", Collections.emptyMap(), 1);
+
+        // Test normal case
+        httpRequest.incrementTimeout(1);
+        assertEquals(2, httpRequest.getTimeout()); // 1*(1+1) = 2
+
+        // Test large value
+        httpRequest.incrementTimeout(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, httpRequest.getTimeout()); // Should have caused overflow and been set to MAX_VALUE
+
+        // Test timeout already at max value
+        httpRequest.incrementTimeout(1);
+        assertEquals(Integer.MAX_VALUE, httpRequest.getTimeout()); // Should not change timeout
+    }
+}

--- a/algoliasearch-core/src/test/java/com/algolia/search/HttpRequestTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/HttpRequestTest.java
@@ -1,29 +1,30 @@
 package com.algolia.search;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.algolia.search.models.HttpMethod;
 import com.algolia.search.models.HttpRequest;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 class HttpRequestTest {
 
-    @Test
-    void testIncrementTimeout() {
-        HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, "/", Collections.emptyMap(), 1);
+  @Test
+  void testIncrementTimeout() {
+    HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, "/", Collections.emptyMap(), 1);
 
-        // Test normal case
-        httpRequest.incrementTimeout(1);
-        assertEquals(2, httpRequest.getTimeout()); // 1*(1+1) = 2
+    // Test normal case
+    httpRequest.incrementTimeout(1);
+    assertEquals(2, httpRequest.getTimeout()); // 1*(1+1) = 2
 
-        // Test large value
-        httpRequest.incrementTimeout(Integer.MAX_VALUE);
-        assertEquals(Integer.MAX_VALUE, httpRequest.getTimeout()); // Should have caused overflow and been set to MAX_VALUE
+    // Test large value
+    httpRequest.incrementTimeout(Integer.MAX_VALUE);
+    assertEquals(
+        Integer.MAX_VALUE,
+        httpRequest.getTimeout()); // Should have caused overflow and been set to MAX_VALUE
 
-        // Test timeout already at max value
-        httpRequest.incrementTimeout(1);
-        assertEquals(Integer.MAX_VALUE, httpRequest.getTimeout()); // Should not change timeout
-    }
+    // Test timeout already at max value
+    httpRequest.incrementTimeout(1);
+    assertEquals(Integer.MAX_VALUE, httpRequest.getTimeout()); // Should not change timeout
+  }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #784
| Need Doc update   | no


## Describe your change

This PR modifies `HttpRequest#incrementTimeout` method to prevent integer overflow. In case of overflow, timeout is set to `Integer.MAX_VALUE`.
