### PR TITLE
fix(search): add abTestID to search result

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchResult.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchResult.java
@@ -33,6 +33,7 @@ public class SearchResult<T> implements Serializable {
   private Integer appliedRelevancyStrictness;
   private Integer nbSortedHits;
   private RenderingContent renderingContent;
+  private Integer abTestID;
 
   public Explain getExplain() {
     return explain;
@@ -139,6 +140,15 @@ public class SearchResult<T> implements Serializable {
 
   public SearchResult<T> setRenderingContent(RenderingContent renderingContent) {
     this.renderingContent = renderingContent;
+    return this;
+  }
+
+  public Integer getAbTestID() {
+    return abTestID;
+  }
+
+  public SearchResult<T> setAbTestID(Integer abTestID) {
+    this.abTestID = abTestID;
     return this;
   }
 
@@ -398,6 +408,9 @@ public class SearchResult<T> implements Serializable {
         + '\''
         + ", renderingContent="
         + renderingContent
+        + '\''
+        + ", abTestID="
+        + abTestID
         + '}';
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | CR-3527
| Need Doc update   | no


## Describe your change

Adds `abTestID` field to `SearchResult`.

[CR-3527]: https://algolia.atlassian.net/browse/CR-3527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ