### PR TITLE
fix(apache): `IOException` as network error

### DIFF
--- a/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
+++ b/algoliasearch-apache/src/main/java/com/algolia/search/ApacheHttpRequester.java
@@ -13,7 +13,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
-import javax.net.ssl.SSLException;
 import org.apache.http.*;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.DeflateDecompressingEntity;
@@ -82,7 +81,7 @@ public final class ApacheHttpRequester implements HttpRequester {
                   || t.getCause() instanceof NoHttpResponseException) {
                 return new HttpResponse(true);
               } else if (t.getCause() instanceof HttpException
-                  || t.getCause() instanceof SSLException) {
+                  || t.getCause() instanceof IOException) {
                 return new HttpResponse().setNetworkError(true);
               }
               throw new AlgoliaRuntimeException(t);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Treat all `IOException` exceptions (not only `SSLException`) as network errors.