### PR TITLE
feat: annotation support for getters

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/Defaults.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/Defaults.java
@@ -35,6 +35,10 @@ public class Defaults {
             .disable(
                 DeserializationFeature
                     .READ_DATE_TIMESTAMPS_AS_NANOSECONDS) // Nano seconds not supported by the
+
+            .disable(
+                SerializationFeature
+                        .FAIL_ON_EMPTY_BEANS)
             // engine
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
   }

--- a/algoliasearch-core/src/main/java/com/algolia/search/SearchIndex.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/SearchIndex.java
@@ -480,7 +480,7 @@ public final class SearchIndex<T>
     Objects.requireNonNull(data, "Data is required.");
     Objects.requireNonNull(createIfNotExists, "createIfNotExists is required.");
 
-    String objectID = AlgoliaUtils.getObjectID(data, clazz);
+    String objectID = AlgoliaUtils.getObjectID(data);
 
     if (requestOptions == null) {
       requestOptions = new RequestOptions();

--- a/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchResult.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/indexing/SearchResult.java
@@ -330,9 +330,9 @@ public class SearchResult<T> implements Serializable {
     return this;
   }
 
-  public int getObjectPosition(@Nonnull String objectID, @Nonnull Class<T> clazz) {
+  public int getObjectPosition(@Nonnull String objectID) {
     return IntStream.range(0, hits.size())
-        .filter(i -> objectID.equals(AlgoliaUtils.getObjectID(hits.get(i), clazz)))
+        .filter(i -> objectID.equals(AlgoliaUtils.getObjectID(hits.get(i))))
         .findFirst()
         .orElse(-1);
   }

--- a/algoliasearch-core/src/main/java/com/algolia/search/util/AlgoliaUtils.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/util/AlgoliaUtils.java
@@ -1,162 +1,94 @@
 package com.algolia.search.util;
 
 import com.algolia.search.exceptions.AlgoliaRuntimeException;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.lang.reflect.Field;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.zone.ZoneRules;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import javax.annotation.Nonnull;
 
 public class AlgoliaUtils {
 
-  /** Checks if the given string is empty or white spaces */
-  public static Boolean isEmptyWhiteSpace(final String stringToCheck) {
-    return stringToCheck.trim().length() == 0;
-  }
+    public static final String PROPERTY_OBJECT_ID = "objectID";
 
-  /** Checks if the given string is null, empty or white spaces */
-  public static Boolean isNullOrEmptyWhiteSpace(final String stringToCheck) {
-    return stringToCheck == null || stringToCheck.trim().length() == 0;
-  }
-
-  private static final ZoneRules ZONE_RULES_UTC = ZoneOffset.UTC.getRules();
-
-  /**
-   * Memory optimization for getZoneRules with the same ZoneOffset (UTC). ZoneRules is immutable and
-   * threadsafe, but getRules method consumes a lot of memory during load testing.
-   */
-  public static OffsetDateTime nowUTC() {
-    final Instant now = Clock.system(ZoneOffset.UTC).instant();
-    return OffsetDateTime.ofInstant(now, ZONE_RULES_UTC.getOffset(now));
-  }
-
-  /**
-   * Ensure that the objectID field or the @JsonProperty(\"objectID\")" is present in the given
-   * class
-   *
-   * @param clazz The class to scan
-   * @throws AlgoliaRuntimeException When the class doesn't have an objectID field or a Jackson
-   *     annotation @JsonProperty(\"objectID\"")
-   */
-  public static <T> void ensureObjectID(@Nonnull Class<T> clazz) {
-    // Try to find the objectID field
-    Field objectIDField = getField(clazz, "objectID");
-
-    // If objectID field doesn't exist, let's check for Jackson annotations in all the fields
-    Optional<Field> optObjectIDField = findObjectIDInAnnotation(clazz);
-
-    if (objectIDField == null && !optObjectIDField.isPresent()) {
-      throw new AlgoliaRuntimeException(
-          "The "
-              + clazz
-              + " must have an objectID property or a Jackson annotation @JsonProperty(\"objectID\")");
-    }
-  }
-
-  /**
-   * Get the objectID of the given class at runtime
-   *
-   * @param clazz The class to scan
-   * @throws AlgoliaRuntimeException When the class doesn't have an objectID field or a Jackson
-   *     annotation @JsonProperty(\"objectID\"")
-   */
-  public static <T> String getObjectID(@Nonnull T data, @Nonnull Class<T> clazz) {
-
-    String objectID = null;
-
-    // Try to find the objectID field
-    try {
-      Field objectIDField = getField(clazz, "objectID");
-      if (objectIDField != null) {
-        objectID = (String) objectIDField.get(data);
-      }
-    } catch (
-        IllegalAccessException
-            ignored) { // Ignored because if it fails we want to move forward on annotations
+    /**
+     * Checks if the given string is empty or white spaces
+     */
+    public static Boolean isEmptyWhiteSpace(final String stringToCheck) {
+        return stringToCheck.trim().isEmpty();
     }
 
-    if (objectID != null) {
-      return objectID;
+    /**
+     * Checks if the given string is null, empty or white spaces
+     */
+    public static Boolean isNullOrEmptyWhiteSpace(final String stringToCheck) {
+        return stringToCheck == null || stringToCheck.trim().isEmpty();
     }
 
-    // If objectID field doesn't exist, let's check for Jackson annotations in all the fields
-    Optional<Field> optObjectIDField = findObjectIDInAnnotation(clazz);
+    private static final ZoneRules ZONE_RULES_UTC = ZoneOffset.UTC.getRules();
 
-    if (optObjectIDField.isPresent()) {
-      Field objectIDField = optObjectIDField.get();
-      try {
-        objectIDField.setAccessible(true);
-
-        objectID = (String) objectIDField.get(data);
-
-        if (objectID != null) {
-          return objectID;
-        }
-
-      } catch (IllegalAccessException ignored) {
-        throw new AlgoliaRuntimeException("Can't access the ObjectID field.");
-      }
+    /**
+     * Memory optimization for getZoneRules with the same ZoneOffset (UTC). ZoneRules is immutable and
+     * thread-safe, but getRules method consumes a lot of memory during load testing.
+     */
+    public static OffsetDateTime nowUTC() {
+        final Instant now = Clock.system(ZoneOffset.UTC).instant();
+        return OffsetDateTime.ofInstant(now, ZONE_RULES_UTC.getOffset(now));
     }
 
-    // If non of the both above the method fails
-    throw new AlgoliaRuntimeException(
-        "The "
-            + clazz
-            + " must have an objectID property or a Jackson annotation @JsonProperty(\"objectID\")");
-  }
-
-  private static Optional<Field> findObjectIDInAnnotation(@Nonnull Class<?> clazz) {
-    List<Field> fields = getFields(clazz);
-    return fields.stream()
-        .filter(
-            f ->
-                f.getAnnotation(JsonProperty.class) != null
-                    && f.getAnnotation(JsonProperty.class).value().equals("objectID"))
-        .findFirst();
-  }
-
-  /**
-   * Recursively search for the given field in the given class
-   *
-   * @param clazz The class to reflect on
-   * @param fieldName The field to reach
-   */
-  private static Field getField(@Nonnull Class<?> clazz, @Nonnull String fieldName) {
-    Class<?> tmpClass = clazz;
-    do {
-      try {
-        Field f = tmpClass.getDeclaredField(fieldName);
-        f.setAccessible(true);
-        return f;
-      } catch (NoSuchFieldException e) {
-        tmpClass = tmpClass.getSuperclass();
-      }
-    } while (tmpClass != null);
-
-    return null;
-  }
-
-  /**
-   * Recursively search for all fields in the given class
-   *
-   * @param clazz The class to reflect on
-   */
-  private static List<Field> getFields(@Nonnull Class<?> clazz) {
-    List<Field> result = new ArrayList<>();
-    Class<?> i = clazz;
-
-    while (i != null && i != Object.class) {
-      Collections.addAll(result, i.getDeclaredFields());
-      i = i.getSuperclass();
+    /**
+     * Ensure that the objectID field or the @JsonProperty(\"objectID\")" is present in the given
+     * class
+     *
+     * @param clazz The class to scan
+     * @throws AlgoliaRuntimeException When the class doesn't have an objectID field or a Jackson
+     *                                 annotation @JsonProperty(\"objectID\"")
+     */
+    public static <T> void ensureObjectID(@Nonnull Class<T> clazz) {
+        BeanDescription introspection = introspectClass(clazz);
+        if (!containsObjectID(introspection)) throw objectIDNotFoundException(clazz);
     }
 
-    return result;
-  }
+    private static <T> AlgoliaRuntimeException objectIDNotFoundException(Class<T> clazz) {
+        return new AlgoliaRuntimeException(
+                "The " + clazz + " must have an objectID property or a Jackson annotation @JsonProperty(\"objectID\")");
+    }
+
+    /**
+     * Checks if the {@value PROPERTY_OBJECT_ID} is present in the classes public fields, getter methods or
+     * annotations using Jackson's {@link BeanDescription}
+     */
+    protected static boolean containsObjectID(BeanDescription introspection) {
+        return introspection.findProperties().stream().anyMatch(d -> PROPERTY_OBJECT_ID.equals(d.getName()));
+    }
+
+    /**
+     * Introspection of the class using Jackson
+     */
+    protected static <T> BeanDescription introspectClass(Class<T> clazz) {
+        ObjectMapper mapper = new ObjectMapper();
+        JavaType type = mapper.getTypeFactory().constructType(clazz);
+        return mapper.getSerializationConfig().introspect(type);
+    }
+
+    /**
+     * Get the objectID of the given class at runtime
+     *
+     * @throws AlgoliaRuntimeException When the class doesn't have an objectID field or a Jackson
+     *                                 annotation @JsonProperty(\"objectID\"")
+     */
+    public static <T> String getObjectID(@Nonnull T data) {
+        return Optional.ofNullable(new ObjectMapper().valueToTree(data)
+                .get(PROPERTY_OBJECT_ID))
+                .map(JsonNode::asText)
+                .orElseThrow(() -> objectIDNotFoundException(data.getClass()));
+    }
+
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/EnsureObjectIDTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/EnsureObjectIDTest.java
@@ -65,7 +65,7 @@ class EnsureObjectIDTest {
     assertThatThrownBy(
             () ->
                 AlgoliaUtils.getObjectID(
-                    new DummyObjectWithoutObjectId(), DummyObjectWithoutObjectId.class))
+                    new DummyObjectWithoutObjectId()))
         .isInstanceOf(AlgoliaRuntimeException.class)
         .hasMessageContaining(
             "must have an objectID property or a Jackson annotation @JsonProperty(\"objectID\")");
@@ -73,7 +73,7 @@ class EnsureObjectIDTest {
     assertThatThrownBy(
             () ->
                 AlgoliaUtils.getObjectID(
-                    new DummyChildWithoutObjectID(), DummyChildWithoutObjectID.class))
+                    new DummyChildWithoutObjectID()))
         .isInstanceOf(AlgoliaRuntimeException.class)
         .hasMessageContaining(
             "must have an objectID property or a Jackson annotation @JsonProperty(\"objectID\")");
@@ -85,7 +85,7 @@ class EnsureObjectIDTest {
     assertThatThrownBy(
             () ->
                 AlgoliaUtils.getObjectID(
-                    new DummyObjectWithWrongAnnotation(), DummyObjectWithWrongAnnotation.class))
+                    new DummyObjectWithWrongAnnotation()))
         .isInstanceOf(AlgoliaRuntimeException.class)
         .hasMessageContaining(
             "must have an objectID property or a Jackson annotation @JsonProperty(\"objectID\")");
@@ -93,7 +93,7 @@ class EnsureObjectIDTest {
     assertThatThrownBy(
             () ->
                 AlgoliaUtils.getObjectID(
-                    new DummyChildWithWrongAnnotation(), DummyChildWithWrongAnnotation.class))
+                    new DummyChildWithWrongAnnotation()))
         .isInstanceOf(AlgoliaRuntimeException.class)
         .hasMessageContaining(
             "must have an objectID property or a Jackson annotation @JsonProperty(\"objectID\")");
@@ -105,15 +105,15 @@ class EnsureObjectIDTest {
     assertThatCode(
             () ->
                 AlgoliaUtils.getObjectID(
-                    new DummyObjectWithObjectID().setObjectID("foo"),
-                    DummyObjectWithObjectID.class))
+                    new DummyObjectWithObjectID().setObjectID("foo")
+                ))
         .doesNotThrowAnyException();
 
     assertThatCode(
             () ->
                 AlgoliaUtils.getObjectID(
-                    (DummyChildWithObjectID) new DummyChildWithObjectID().setObjectID("foo"),
-                    DummyChildWithObjectID.class))
+                    (DummyChildWithObjectID) new DummyChildWithObjectID().setObjectID("foo")
+                ))
         .doesNotThrowAnyException();
   }
 
@@ -123,14 +123,14 @@ class EnsureObjectIDTest {
     assertThatCode(
             () ->
                 AlgoliaUtils.getObjectID(
-                    new DummyObjectWithAnnotation().setId("foo"), DummyObjectWithAnnotation.class))
+                    new DummyObjectWithAnnotation().setId("foo")))
         .doesNotThrowAnyException();
 
     assertThatCode(
             () ->
                 AlgoliaUtils.getObjectID(
-                    (DummyChildWithAnnotation) new DummyChildWithAnnotation().setId("foo"),
-                    DummyChildWithAnnotation.class))
+                    (DummyChildWithAnnotation) new DummyChildWithAnnotation().setId("foo")
+                ))
         .doesNotThrowAnyException();
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/integration/index/SearchTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/integration/index/SearchTest.java
@@ -88,11 +88,11 @@ public abstract class SearchTest {
         searchFacetFuture);
 
     assertThat(searchAlgoliaFuture.get().getHits()).hasSize(2);
-    assertThat(searchAlgoliaFuture.get().getObjectPosition("nicolas-dessaigne", Employee.class))
+    assertThat(searchAlgoliaFuture.get().getObjectPosition("nicolas-dessaigne"))
         .isEqualTo(0);
-    assertThat(searchAlgoliaFuture.get().getObjectPosition("julien-lemoine", Employee.class))
+    assertThat(searchAlgoliaFuture.get().getObjectPosition("julien-lemoine"))
         .isEqualTo(1);
-    assertThat(searchAlgoliaFuture.get().getObjectPosition("unknown", Employee.class))
+    assertThat(searchAlgoliaFuture.get().getObjectPosition("unknown"))
         .isEqualTo(-1);
     assertTrue(searchAlgoliaFuture.get().getExhaustiveNbHits());
     assertThat(searchElonFuture.get().getQueryID()).isNotNull();

--- a/algoliasearch-core/src/test/java/com/algolia/search/util/AlgoliaUtilsTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/util/AlgoliaUtilsTest.java
@@ -1,0 +1,93 @@
+package com.algolia.search.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BeanDescription;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Created by Marian at 17.12.2023
+ */
+class AlgoliaUtilsTest {
+
+    protected interface SetObjectId {
+        void set(String objectId);
+    }
+
+    protected static class SomeClassWithPublicField implements SetObjectId {
+
+        public String objectID;
+
+        @Override
+        public void set(String objectId) {
+            this.objectID = objectId;
+        }
+    }
+
+    protected static class SomeClassWithGetter implements SetObjectId {
+
+        private String objectID;
+
+        public String getObjectID() {
+            return objectID;
+        }
+
+        @Override
+        public void set(String objectId) {
+            this.objectID = objectId;
+        }
+    }
+
+
+    protected static class SomeClassWithAnnotation implements SetObjectId {
+
+        @JsonProperty(AlgoliaUtils.PROPERTY_OBJECT_ID)
+        private String objectID;
+
+        @Override
+        public void set(String objectId) {
+            this.objectID = objectId;
+        }
+
+    }
+
+    protected static class SomeClassWithGetterAndAnnotation implements SetObjectId {
+
+        private String objectID;
+
+        @JsonProperty(AlgoliaUtils.PROPERTY_OBJECT_ID)
+        public String getWithCustomName() {
+            return objectID;
+        }
+
+        @Override
+        public void set(String objectId) {
+            this.objectID = objectId;
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            SomeClassWithPublicField.class,
+            SomeClassWithGetter.class,
+            SomeClassWithAnnotation.class,
+            SomeClassWithGetterAndAnnotation.class})
+    void containsObjectID(Class<?> clazz) {
+        BeanDescription introspection = AlgoliaUtils.introspectClass(clazz);
+        assertTrue(AlgoliaUtils.containsObjectID(introspection));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            SomeClassWithPublicField.class,
+            SomeClassWithGetter.class,
+            SomeClassWithAnnotation.class,
+            SomeClassWithGetterAndAnnotation.class})
+    void extractObjectID(Class<? extends SetObjectId> clazz) throws Exception {
+        SetObjectId instance = clazz.getDeclaredConstructor().newInstance();
+        instance.set("12345");
+        assertEquals("12345", AlgoliaUtils.getObjectID(instance));
+    }
+}


### PR DESCRIPTION


| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

This change will let you use `@JsonProperty("objectID")` annotations on custom Getter methods.

To make things easier, I've dropped the custom reflection logic in favor of Jackson's internal introspection logic. This allows checking for the objectID within property names, getters and annotation values at once.

I've additionally removed the validation for objectIDs entirely for the "getObjectID" method and used an Optional fallback instead.

The tests are within an extra class to not bloat the original tests.

## What problem is this fixing?

If you are working with base classes that already come with an internal ID field you want to use as the "Object ID", and you don't want to modify the base class by adding the `@JsonProperty("objectID")` annotation, you can only do that by using a custom getter in your child class. 

The implementation supported only scans on the field name and field annotations, not method annotations.

## Additional

I've added 

```
            .disable(
                SerializationFeature
                        .FAIL_ON_EMPTY_BEANS)
```

Not sure if it has any side effects you do not want. Stumbled accross this case within my tests and imo it won't hurt.