### PR TITLE
fix(rules): allow one-sided timeRange

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/models/rules/TimeRange.java
@@ -55,8 +55,12 @@ class TimeRangeSerializer extends JsonSerializer<TimeRange> {
   public void serialize(TimeRange value, JsonGenerator gen, SerializerProvider serializers)
       throws IOException {
     gen.writeStartObject();
-    gen.writeObjectField("from", value.getFrom().toEpochSecond());
-    gen.writeObjectField("until", value.getUntil().toEpochSecond());
+    if (value.getFrom() != null) {
+      gen.writeObjectField("from", value.getFrom().toEpochSecond());
+    }
+    if (value.getUntil() != null) {
+      gen.writeObjectField("until", value.getUntil().toEpochSecond());
+    }
     gen.writeEndObject();
   }
 }
@@ -66,14 +70,20 @@ class TimeRangeDeserializer extends JsonDeserializer<TimeRange> {
   @Override
   public TimeRange deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
     JsonNode node = p.getCodec().readTree(p);
-    // 'from' unix timestamp
-    long fromTimestamp = node.get("from").asLong();
-    Instant fromInstant = Instant.ofEpochSecond(fromTimestamp);
-    OffsetDateTime from = OffsetDateTime.ofInstant(fromInstant, ZoneOffset.UTC);
-    // 'until' unix timestamp
-    long untilTimestamp = node.get("until").asLong();
-    Instant untilInstant = Instant.ofEpochSecond(untilTimestamp);
-    OffsetDateTime until = OffsetDateTime.ofInstant(untilInstant, ZoneOffset.UTC);
+    OffsetDateTime from = null, until = null;
+    if (node.hasNonNull("from")) {
+      // 'from' unix timestamp
+      long fromTimestamp = node.get("from").asLong();
+      Instant fromInstant = Instant.ofEpochSecond(fromTimestamp);
+      from = OffsetDateTime.ofInstant(fromInstant, ZoneOffset.UTC);
+    }
+    if (node.hasNonNull("until")) {
+      // 'until' unix timestamp
+      long untilTimestamp = node.get("until").asLong();
+      Instant untilInstant = Instant.ofEpochSecond(untilTimestamp);
+      until = OffsetDateTime.ofInstant(untilInstant, ZoneOffset.UTC);
+    }
+    
     return new TimeRange(from, until);
   }
 }

--- a/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/JacksonParserTest.java
@@ -1012,6 +1012,23 @@ class JacksonParserTest {
   }
 
   @Test
+  void rulesValidityTimeRange_oneSided() throws IOException {
+    ZoneOffset offset = ZoneOffset.of("+05:30");
+    // Nanoseconds precisions will be lost and should not be considered.
+    TimeRange timerange =
+        new TimeRange(
+            OffsetDateTime.of(2021, 5, 1, 0, 0, 0, 0, offset),
+            null);
+
+    String json = Defaults.getObjectMapper().writeValueAsString(timerange);
+    assertThat(json).isEqualTo("{\"from\":1619807400}");
+
+    TimeRange retrieveTimeRange = Defaults.getObjectMapper().readValue(json, TimeRange.class);
+    assertThat(timerange.getFrom()).isEqualTo(retrieveTimeRange.getFrom());
+    assertThat(timerange.getUntil()).isNull();
+  }
+
+  @Test
   void recommendations() throws JsonProcessingException {
     String json =
         "{\"results\":[{\"hits\":[{\"_highlightResult\":{\"category\":{\"matchLevel\":\"none\",\"matchedWords\":[],\"value\":\"Men - T-Shirts\"},\"image_link\":{\"matchLevel\":\"none\",\"matchedWords\":[],\"value\":\"https:\\/\\/example.org\\/image\\/D05927-8161-111-F01.jpg\"},\"name\":{\"matchLevel\":\"none\",\"matchedWords\":[],\"value\":\"Jirgi Half-Zip T-Shirt\"}},\"_score\":32.72,\"category\":\"Men - T-Shirts\",\"image_link\":\"https:\\/\\/example.org\\/image\\/D05927-8161-111-F01.jpg\",\"name\":\"Jirgi Half-Zip T-Shirt\",\"objectID\":\"D05927-8161-111\",\"position\":105,\"url\":\"men\\/t-shirts\\/d05927-8161-111\"}],\"hitsPerPage\":1,\"nbHits\":1,\"nbPages\":1,\"page\":0,\"processingTimeMS\":6,\"renderingContent\":{}}]}";


### PR DESCRIPTION
Jira ticket: [DI-4067](https://algolia.atlassian.net/browse/DI-4067)

The timeRange for rules can be one-sided, where either `from` or `until` can be null.

[DI-4067]: https://algolia.atlassian.net/browse/DI-4067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ