### PR TITLE
fix(uber): strip unused logging adapters from shaded uber jar

### DIFF
--- a/algoliasearch-apache-uber/pom.xml
+++ b/algoliasearch-apache-uber/pom.xml
@@ -94,6 +94,11 @@
                                     <artifact>commons-logging:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/**</exclude>
+                                        <exclude>org/apache/commons/logging/impl/Log4JLogger.class</exclude>
+                                        <exclude>org/apache/commons/logging/impl/AvalonLogger.class</exclude>
+                                        <exclude>org/apache/commons/logging/impl/LogKitLogger.class</exclude>
+                                        <exclude>org/apache/commons/logging/impl/Jdk13LumberjackLogger.class</exclude>
+                                        <exclude>org/apache/commons/logging/impl/ServletContextCleaner.class</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>


### PR DESCRIPTION
Remove dead commons-logging adapter classes (Log4JLogger, AvalonLogger, LogKitLogger, Jdk13LumberjackLogger, ServletContextCleaner) from the apache-uber shaded jar. These are never used at runtime — the shaded LogFactoryImpl falls through to Jdk14Logger — and their presence triggers false positives in security scanners.