### PR TITLE
fix(java): ensure waitTask exception propagation

### DIFF
--- a/algoliasearch-core/src/main/java/com/algolia/search/TaskUtils.java
+++ b/algoliasearch-core/src/main/java/com/algolia/search/TaskUtils.java
@@ -3,6 +3,7 @@ package com.algolia.search;
 import com.algolia.search.exceptions.AlgoliaApiException;
 import com.algolia.search.exceptions.AlgoliaRetryException;
 import com.algolia.search.exceptions.AlgoliaRuntimeException;
+import com.algolia.search.exceptions.LaunderThrowable;
 import com.algolia.search.models.RequestOptions;
 import com.algolia.search.models.common.TaskStatusResponse;
 import java.util.Objects;
@@ -38,11 +39,13 @@ class TaskUtils {
 
       try {
         response = getTaskAsync.apply(taskId, requestOptions).get();
-      } catch (InterruptedException | ExecutionException e) {
-        // If the future was cancelled or the thread was interrupted or future completed
-        // exceptionally
-        // We stop
-        break;
+      } catch (InterruptedException e) {
+        // Restore the interrupted status and surface the failure
+        Thread.currentThread().interrupt();
+        throw new AlgoliaRuntimeException(e);
+      } catch (ExecutionException e) {
+        // Surface the underlying error
+        throw LaunderThrowable.launder(e);
       }
 
       if (Objects.equals("published", response.getStatus())) return;

--- a/algoliasearch-core/src/test/java/com/algolia/search/TaskUtilsTest.java
+++ b/algoliasearch-core/src/test/java/com/algolia/search/TaskUtilsTest.java
@@ -1,0 +1,71 @@
+package com.algolia.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.algolia.search.exceptions.AlgoliaApiException;
+import com.algolia.search.exceptions.AlgoliaRuntimeException;
+import com.algolia.search.models.RequestOptions;
+import com.algolia.search.models.common.TaskStatusResponse;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TaskUtilsTest {
+
+  private static TaskStatusResponse status(String status) {
+    return new TaskStatusResponse().setStatus(status);
+  }
+
+  @Test
+  @DisplayName("waitTask surfaces polling failures instead of silently exiting")
+  void propagatesExecutionException() {
+    AlgoliaApiException cause = new AlgoliaApiException("boom", 500);
+    BiFunction<Long, RequestOptions, CompletableFuture<TaskStatusResponse>> failing =
+        (taskId, requestOptions) -> {
+          CompletableFuture<TaskStatusResponse> future = new CompletableFuture<>();
+          future.completeExceptionally(cause);
+          return future;
+        };
+
+    // Before the fix this returned void (the exception was swallowed by a `break`), which let
+    // callers such as replaceAllObjects proceed as if the task had completed. It must now throw
+    // the unwrapped exception so the caller can abort.
+    assertThatThrownBy(() -> TaskUtils.waitTask(1L, 1L, null, failing))
+        .isInstanceOf(AlgoliaApiException.class)
+        .isSameAs(cause);
+  }
+
+  @Test
+  @DisplayName("waitTask restores the interrupt flag and throws when the thread is interrupted")
+  void restoresInterruptFlagOnInterruption() {
+    BiFunction<Long, RequestOptions, CompletableFuture<TaskStatusResponse>> neverCompletes =
+        (taskId, requestOptions) -> new CompletableFuture<>();
+
+    Thread.currentThread().interrupt();
+    try {
+      assertThatThrownBy(() -> TaskUtils.waitTask(1L, 1L, null, neverCompletes))
+          .isInstanceOf(AlgoliaRuntimeException.class);
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    } finally {
+      // Clear the flag so it does not leak into other tests.
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  @DisplayName("waitTask keeps polling until the task is published")
+  void retriesUntilPublished() {
+    AtomicInteger calls = new AtomicInteger();
+    BiFunction<Long, RequestOptions, CompletableFuture<TaskStatusResponse>> eventually =
+        (taskId, requestOptions) ->
+            CompletableFuture.completedFuture(
+                status(calls.incrementAndGet() < 3 ? "notPublished" : "published"));
+
+    assertThatCode(() -> TaskUtils.waitTask(1L, 1L, null, eventually)).doesNotThrowAnyException();
+    assertThat(calls.get()).isEqualTo(3);
+  }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | [API-473]
| Need Doc update   | no

Jira ticket: [API-473]

## Describe your change

`TaskUtils.waitTask` polls task status in a `while (true)` loop and, on `InterruptedException` / `ExecutionException` from `getTask`, silently `break`ed out of the loop. Because `waitTask` returns `void`, a swallowed exception was indistinguishable from a genuine `"published"` confirmation.

This PR replaces the silent `break` with proper exception propagation, mirroring the `LaunderThrowable` pattern already used throughout the client:

- `InterruptedException` → restore the thread's interrupt flag, then rethrow as `AlgoliaRuntimeException`.
- `ExecutionException` → unwrap the real cause via `LaunderThrowable.launder`, surfacing the underlying `AlgoliaApiException` / `AlgoliaRetryException` / `AlgoliaRuntimeException`.

After the change the loop has only two exits: a real `"published"` status (`return`) or a thrown exception. It can no longer return as if a task completed when it did not.

## What problem is this fixing?

If `waitTask` silently exited after the **copy** step (a transient network error, or `getTask` being retried on a host that had not yet registered the task), `replaceAllObjects` proceeded as though the copy had completed:

1. settings / rules / synonyms were **not** confirmed copied into the tmp index;
2. records were batched into the tmp index;
3. the tmp index was atomically moved over the main index.

**Result:** the main index keeps its records but loses its settings, rules, and synonyms (reset to defaults) — a silent partial wipeout, with no error surfaced to the caller. This is exactly the incident reported in [CR-11430].

This bug is unique to the Java **v3** (legacy) client — v4 and every other legacy client propagate the exception. v4 is already safe via `TaskUtils.retryUntil` (no `try/catch` around the supplier) plus a `replaceAllObjects` cleanup wrapper.

[API-473]: https://algolia.atlassian.net/browse/API-473
[CR-11430]: https://algolia.atlassian.net/browse/CR-11430
